### PR TITLE
add docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,11 @@ docker run -ti --rm \
       -address :5000 \
       -web-port :6001
 ```
+
+### Docker Compose
+
+```
+docker-compose up
+```
+
+Open [http://localhost:8000](http://localhost:8000).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3"
+services:
+  manager:
+    image: skycoin/skywire
+    ports:
+      - 8000:8000
+  node:
+    image: skycoin/skywire
+    volumes:
+      - skywire-data:/root/.skywire
+    command: node -connect-manager -manager-address manager:5998 -manager-web manager:8000 -address :5000 -web-port :6001
+    ports:
+      - 5000:5000
+      - 6001:6001
+volumes:
+  skywire-data:


### PR DESCRIPTION
Using the recently added Dockerfile and instructions I've added a `docker-compose.yml` file.

This condenses the series of commands in the README into an easy to read config and allows spinning up a fully functional skywire node and manager with a single line when using docker-compose.

