### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ cd $GOPATH/bin
 If you need to close the current window and continue to run Skywire Manager, you can use
 ```
 cd $GOPATH/bin
-nohup ./manager -web-dir ${GOPATH}/src/github.com/skycoin/skywire/static/skywire-manager > /dev/null 2>&1 & echo $! > manager.pid
+nohup ./manager -web-dir ${GOPATH}/src/github.com/skycoin/skywire/static/skywire-manager > /dev/null 2>&1 &sleep 3
 ```
 
 `Note: do not execute the above two commands at the same time, just select one of them.`
@@ -71,7 +71,7 @@ Open a new command window
 
 ```
 cd $GOPATH/bin
-./node -connect-manager -manager-address 127.0.0.1:5998 -manager-web 127.0.0.1:8000
+./node -connect-manager -manager-address 127.0.0.1:5998 -manager-web 127.0.0.1:8000 -discovery-address discovery.skycoin.net:5999-034b1cd4ebad163e457fb805b3ba43779958bba49f2c5e1e8b062482904bacdb68 -address :5000 -web-port :6001 
 ```
 
 `tip: If you run with the above command, you will not be able to close the current window or you will close Skywire Node.`
@@ -79,7 +79,7 @@ cd $GOPATH/bin
 If you need to close the current window and continue to run Skywire Manager, you can use
 ```
 cd $GOPATH/bin
-nohup ./node -connect-manager -manager-address 127.0.0.1:5998 -manager-web 127.0.0.1:8000 > /dev/null 2>&1 & echo $! > node.pid
+nohup ./node -connect-manager -manager-address :5998 -manager-web :8000 -discovery-address discovery.skycoin.net:5999-034b1cd4ebad163e457fb805b3ba43779958bba49f2c5e1e8b062482904bacdb68 -address :5000 -web-port :6001 > /dev/null 2>&1 &cd /
 ```
 
 #### Stop Skywire Manager and Node.
@@ -124,7 +124,7 @@ Click "Add" to Add the configuration,
 ```
 Proxy Type: SOCKS5
 IP address, DNS name, server name: 127.0.0.1
-Port: 可用端口
+Port: 9443
 ```
 And then finally click "Save"
 
@@ -193,6 +193,21 @@ Open [http://localhost:8000](http://localhost:8000).
 Note: these images can only be run on [Orange Pi Prime](http://www.orangepi.cn/OrangePiPrime/index_cn.html).
 
 ### IP presetted system images
+
+Default password is 'samos'.
+
+Run this **once if you're using the official images** to change the remote repository:
+```
+git remote set-url origin https://github.com/skycoin/skywire.git
+```
+Stay up to date by updating via git:
+```
+cd $GOPATH/src/github.com/skycoin/skywire
+git reset --hard
+git clean -f -d
+git pull origin master
+go install -v ./...
+```
 
 Manager system image package contains Skywire Manager and a Skywire Node, other Node system image package only launch a Node.
 


### PR DESCRIPTION
- Add default password for the new images 
- Change port for using SOCKS5 proxy from chinese to 9443
- Updated the commands to start the manager & node to the commands from the skywire installation pdf guide
- Added commands to update the official images via git + change the remote repository from samoslab to our skywire repository.