### PR TITLE
Document Skywire Manager and Node APIs (partial - wip)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ Skywire is still under heavy development.
 * [Run Skywire](#run-skywire)
 * [Docker](#docker)
 * [System Images Download Url](#images)
+* Developers Guide
+  * [Manager API](docs/api/ManagerAPI.md)
+  * [Node API](docs/api/NodeAPI.md)
 
-### Requirements
+## Requirements
 
 * golang 1.9+
 

--- a/docs/api/ManagerAPI.md
+++ b/docs/api/ManagerAPI.md
@@ -1,0 +1,441 @@
+# Skywire Manager API Documentation
+**Note: This document is a work in progress**
+
+The following describes the Web API for the Skywire Manager (`manager`) application. You will need access to a running instance this application in order to utilise the APIs.
+
+Examples provided below assume the Manager is running on the local machine (127.0.0.1). The default port for accessing the API is `8000`. 
+All Node and Application keys have been deliberatly altered to ensure they are invalid.
+
+## Manager API
+The following API services are made avaiable by the Skywire Manager application (`manager`):
+- [Manager](#manager)
+    - [Login](#login)
+    - [Check Login](#heck-login)
+    - [Change Password](#update-password)
+    - [Manager Req](#manager-request-connection)
+    - [Manager Term](#manager-term)
+    - [Get Manager Port](#get-manager-port)
+    - [Get Token](#get-token)
+- [Connections](#run)
+    - [Get All Connections](#get-all-connections)
+    - [Get Manager Information](#get-manager-information)
+    - [Get Node Information](#get-node-information)
+    - [Set Node Configuration](#set-node-configuration)
+    - [Get Node Configuration](#get-node-configuration)
+    - [Save Client Connection](#save-client-connection)
+    - [Remove Client Conneciton](#remove-client-connection)
+    - [Edit Client Connection](#edit-client-connection)
+    - [Get Client Connection](#get-client-connection)
+
+### Login
+Login (authenticate) to the Manager. This is the equivelant of logging into the Manager from the Web UI and is a pre-requisit for a number of other API calls.
+
+Successfuly calling this API will setup an authenticated session with the Manager, and a session cookie will be provided back to the caller as part of the response payload. The session cookie is required as input to a number of other APIs.
+
+The password must be provided as the value for the `pass` parameter.
+The following validation is performed on the value provided for `pass`:
+- Not less than 4 or larger than 20 characters. The call will return `false` if this condition is not met.
+- Compares a hashed version of the provided password against the stored password hash. If they are not the same the service will return `false`.
+
+#### Usage
+```
+URI: /login
+Method: Post
+```
+
+Example:
+```sh
+curl -X "POST" "http://127.0.0.1:8000/login" \
+     -H 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' \
+     --data-urlencode "pass=example-password"
+```
+
+Successful Response:
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Set-Cookie: SWSId=1134c7bfcfa34d5c1015dfd473ab0cfa; Path=/; Expires=Wed, 18 Jul 2018 13:44:36 GMT; Max-Age=3600; HttpOnly
+Date: Wed, 18 Jul 2018 12:44:36 GMT
+Content-Length: 4
+Connection: close
+
+true
+```
+
+Error Response:
+```
+HTTP/1.1 500 Internal Server Error
+Content-Type: text/plain; charset=utf-8
+X-Content-Type-Options: nosniff
+Date: Wed, 18 Jul 2018 12:42:22 GMT
+Content-Length: 22
+Connection: close
+
+authentication failed
+```
+
+### Check Login
+Check Login verifies that the current session is still authorised with the Manager. If an error response is returned, the client must Login again to re-authenticate.
+
+#### Usage
+```
+URI: /checkLogin
+Method: Post
+```
+Example:
+```sh
+## Manager - checkLogin
+curl -X "POST" "http://127.0.0.1:8000/checkLogin" \
+     -H 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' \
+     -H 'Cookie: SWSId=1134c7bfcfa34d5c1015dfd473ab0cfa'
+
+```
+
+Successful Response:
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Date: Fri, 20 Jul 2018 10:33:22 GMT
+Content-Length: 32
+Connection: close
+
+6230fa3ce167dc9afcac12fe1a0125fc
+```
+
+Error Response:
+```
+HTTP/1.1 302 Found
+Content-Type: text/plain; charset=utf-8
+Set-Cookie: SWSId=1134c7bfcfa34d5c1015dfd473ab0cfa; Path=/; Expires=Fri, 20 Jul 2018 11:31:43 GMT; Max-Age=3600; HttpOnly
+X-Content-Type-Options: nosniff
+Date: Fri, 20 Jul 2018 10:31:43 GMT
+Content-Length: 18
+Connection: close
+
+Unauthorized
+false
+```
+
+### Update Password
+Updates (changes) the Manager password.
+
+Both the old and new passwords must be provided as values for the `oldPass` and `newPass` parameters.
+The following validation is performed on both values, with errors returned of the validation fails:
+- Not less than 4 or larger than 20 characters.
+- The new password is not the system default password.
+- The old (current) password is correct.
+- The new password is successfully saved.
+
+Note that the current authenticated session is destroyed when the password is changed. You will need to re-authenticate with the manager using the new password.s
+
+#### Usage
+```
+URI: /updatePass
+Method: Post
+```
+
+Example:
+```sh
+curl -X "POST" "http://127.0.0.1:8000/updatePass" \
+     -H 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' \
+     --data-urlencode "oldPass=oldtest" \
+     --data-urlencode "newPass=newtest"
+
+```
+
+Successful Response:
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Set-Cookie: SWSId=; Path=/; Expires=Fri, 20 Jul 2018 11:01:26 GMT; Max-Age=0; HttpOnly
+Date: Fri, 20 Jul 2018 11:01:26 GMT
+Content-Length: 4
+Connection: close
+
+true
+```
+
+Error Response:
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Date: Fri, 20 Jul 2018 11:03:07 GMT
+Content-Length: 28
+Connection: close
+
+New password length is 4~20.
+```
+
+### Manager Request
+#### Usage
+```
+URI: /req
+Method: Post
+```
+Example:
+```sh
+```
+
+Response:
+```json
+```
+
+### Manager Term
+#### Usage
+```
+URI: /term
+Method: Post
+```
+Example:
+```sh
+```
+
+Response:
+```json
+```
+
+### Get Manager Port
+Retreives the Port number that is used by the Manager. The default is `8000`.
+
+#### Usage
+```
+URI: /getPort
+Method: Get
+```
+Example:
+```sh
+curl "http://127.0.0.1:8000/getPort" \
+     -H 'Authorization: ' \
+     -H 'Cookie: SWSId=bdfbdcda4981101816c1e4b57de1e5de'
+```
+
+Response:
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Date: Fri, 20 Jul 2018 11:28:22 GMT
+Content-Length: 4
+Connection: close
+
+8000
+```
+
+### Get Token
+Get an API authentication token from the Manager. This is a pre-requisit for calling a number of APIs.
+
+The `token` returned in the body of the response (as per the example below) is required as a parameter for other API calls.
+
+#### Usage
+
+```
+URI: /getToken
+Method: Get
+```
+
+Example Request:
+```sh
+curl "http://127.0.0.1:8000/getToken"
+```
+
+Example Response:
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Date: Wed, 18 Jul 2018 11:53:12 GMT
+Content-Length: 64
+Connection: close
+
+bf43103c60b1eb30f8cacd619f0b4c7c8feacd6e0fc40ff1c6d3d3573c1d6fd7
+```
+
+## Connections
+### Get All Connections
+Get all currently active Node connections from the Manager. There are currently no pre-requisits for calling this API (do not need to be logged in or authenticated).
+
+If the request is successful a JSON array containing zero, one or more Node connections (`Conn struct`) will be returned. This represents the list of Nodes currently connected to the Manager.
+
+The `Conn struct` contains the following elements:
+* Key (`string`) - The Node key.
+* Type (`string`) - The connection type. Can be either `TCP` or `UDP`.
+* SendBytes (`unit64`) - The number of bytes that have been sent to this node.
+* RecvBytes (`unit64`) - The number of bytes that have been received by this node.
+* LastActTime (`int64`) - The last time the Manager recieved an Acknowledgement from the Node.
+* StartTime (`int64`) - The time the Node was started.
+
+#### Usage
+
+```
+URI: /conn/getAll
+Method: Get
+```
+
+Example Request:
+```sh
+curl "http://127.0.0.1:8000/conn/getAll"
+```
+
+Successful Response:
+```json
+[
+  {
+    "key": "01baac57c217b77c70c2c71b78e2445f14a9fc6397341eaab23fec62c6bac42f1c",
+    "type": "TCP",
+    "send_bytes": 1001,
+    "recv_bytes": 1127,
+    "last_ack_time": 55,
+    "start_time": 4615
+  }
+
+  {
+    "key": "01bcaf37c253b77c70c2c74a78e2445f14a9ff6397341eaab01fec62c3bfc41a1c",
+    "type": "TCP",
+    "send_bytes": 100,
+    "recv_bytes": 115,
+    "last_ack_time": 35,
+    "start_time": 4011
+  }
+]
+```
+
+Error Response:
+```
+HTTP/1.1 500 Internal Server Error
+```
+
+### Get Manager Information
+Get information about the Manager. There are currently no pre-requisits for calling this API (do not need to be logged in or authenticated).
+
+If the request is successful the result provided in the response body is a `string` composed of the following elements in the following format:
+```
+[Host]:[Port]-[Manager Public Key]
+```
+
+#### Usage
+```
+URI: /getServerInfo
+Method: Get
+```
+
+Example:
+```sh
+curl "http://127.0.0.1:8000/conn/getServerInfo"
+```
+
+Successful Response:
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Date: Wed, 18 Jul 2018 12:14:35 GMT
+Content-Length: 81
+Connection: close
+
+127.0.0.1:5998-110510c20ac843f63fb1d001b5c1e23b9b46ce6efb9a2c57379f8a67b976af0c11
+```
+
+Error Response:
+```
+HTTP/1.1 500 Internal Server Error
+```
+
+### Get Node
+Get detailed information from the manager about the specified Node. The Node key must be passed as a query string to the URI.
+
+#### Usage
+```
+URI: /conn/getNode?key={node=key}
+Method: Post
+```
+Example:
+```sh
+curl -X "POST" "http://127.0.0.1:8000/conn/getNode?key=06bfac57c217b77c70c2c71b78e2445f14a9fc6397341eaab23fec62c6bac42c1c" \
+     -H 'Cookie: SWSId=aeecf9e41466555a16f9a5891e084eb6'
+```
+
+Response:
+```json
+{"type":"TCP","addr":"127.0.0.1:6001","send_bytes":322,"recv_bytes":455,"last_ack_time":22,"start_time":82}
+```
+
+### Set Node Configuration
+#### Usage
+```
+URI: /conn/setNodeConfig
+Method: TBA
+```
+Example:
+```sh
+```
+
+Response:
+```json
+```
+
+### Get Node Configuration
+#### Usage
+```
+URI: /conn/getNodeConfig
+Method: TBA
+```
+Example:
+```sh
+```
+
+Response:
+```json
+```
+
+### Save Client Connection
+#### Usage
+```
+URI: /conn/saveClientConnection
+Method: TBA
+```
+Example:
+```sh
+```
+
+Response:
+```json
+```
+
+### Remove Client Connections
+#### Usage
+```
+URI: /conn/removeClientConnections
+Method: TBA
+```
+Example:
+```sh
+```
+
+Response:
+```json
+```
+
+### Edit Client Connection
+#### Usage
+```
+URI: /conn/editClientConnection
+Method: TBA
+```
+Example:
+```sh
+```
+
+Response:
+```json
+```
+
+### GetClientConnection
+#### Usage
+```
+URI: /conn/getClientConnection
+Method: TBA
+```
+Example:
+```sh
+```
+
+Response:
+```json
+```

--- a/docs/api/NodeAPI.md
+++ b/docs/api/NodeAPI.md
@@ -1,0 +1,394 @@
+# Skywire Node API Documentation
+**Note: This document is a work in progress**
+
+The following describes the Web API for the Skywire Node (`node`) application. You will need access to a running instance of both the `manager` and `node`  applications in order to utilise the APIs. Node: Some `node` APIs first require authorisation from the `manager`.
+
+Examples provided below assume the Node is running on the local machine (127.0.0.1). The default port for accessing the API is `6001`. 
+All Node and Application keys have been deliberatly altered to ensure they are invalid.
+
+## Node API
+The following API services are made avaiable by the Skywire Node application (`node`):
+- [NODE](#node)
+    - [Get Node Signature](#get-node-signature)
+    - [Get Node Information](#get-node-information)
+    - [Get Node Message](#get-node-message)
+    - [Get Node Applications](#get-node-applications)
+    - [Reboot Node](#reboot-node)
+- [RUN](#run)
+    - [Run SSHS](#run-sshs)
+    - [Run SSHC](#run-sshc)
+    - [sockss](#run-sockss)
+    - [socksc](#run-socksc)
+    - [Update](#run-update)
+    - [Check Update](#run-checkUpdate)
+    - [Run Shell](#run-shell)
+    - [Run Command](#run-cmd)
+    - [Get Shell Outpot](#get-shell-output)
+    - [Search for Services](#search-for-services)
+    - [Search for Services Results](#search-for-services-results)
+    - [Set Autostart Config](#set-autostart-config)
+    - [Close Application](#close-application)
+    - [TERM](#run-term)
+
+
+### Get Node Signature
+#### Usage
+```
+URI: /node/getSig
+Method: TBA
+```
+Example:
+```sh
+```
+
+Response:
+```json
+```
+
+### Get Node Information
+Get information about the specific node the request is being made against.
+
+
+You must successfully `/login` on the Manager to aquire a session cookie before calling this API. A valid Manager session cookie must be passed along with this request.
+
+#### Usage
+```
+URI: /node/getInfo
+Method: Get
+```
+
+Request:
+```sh
+curl "http://127.0.0.1:6001/node/getInfo?token=ca51143c60b1ab2078cacd619f1c4f7a8feacd6e0fc40af1c5d3d3573c1d1ac5" \
+     -H 'Cookie: SWSId=1134c7bfcfa34d5c1015dfd473ab0cfa;'
+```
+
+Response:
+```json
+{"discoveries":{"discovery.skycoin.net:5999-034b1cd4ebad163e457fb805b3ba43779958bba49f2c5e1e8b062482904bacdb68":true},"transports":null,"app_feedbacks":null,"version":"0.1.0","tag":"dev","os":"darwin"}
+```
+
+### Get Node Message
+#### Usage
+```
+URI: /node/getMsg
+Method: TBA
+```
+
+Example:
+```sh
+```
+
+Response:
+```json
+```
+	
+### Get Node Applications
+Retrieves a list of the Skywire applications that are currently active and running on the Node.
+
+The response provided will be an array of running applications, specifying the application `key` and `attribure` which defines to the type of application.
+
+#### Usage
+```
+URI: /node/getApps
+Method: Get
+```
+
+Example:
+```sh
+curl "http://127.0.0.1:6001/node/getApps?token=261f61d536c89ecb0e51a31c1a438a278e298e61297dab9afa20199f264bf41c" \
+     -H 'Cookie: SWSId=12384f4a4e2c60c160bdc190d0b1f331'
+```
+
+Response:
+```json
+[{"key":"01c8d1cfb7167371ce2ba8fd7c7341bca0c2a511052650164bcb368386232617ac","attributes":["sockss"],"allow_nodes":null}]
+```
+
+### Reboot Node
+Reboots (restarts) the Node application. 
+An example usage of this API can be found in the Manager Web UI.
+
+#### Usage
+```
+URI: /node/reboot
+Method: TBA
+```
+
+Example:
+```sh
+```
+
+Response:
+```
+```
+
+## Run
+
+### Run SSHS
+Runs (starts) the Skywire `sshs` (SSH Server) application on the Node.
+
+#### Usage
+```
+URI: /node/run/sshs
+Method: TBA
+```
+
+Example:
+```sh
+```
+
+Response:
+```
+```
+
+### Run SSHC
+Runs (starts) the Skywire `sshc` (SSH Client) application on the Node.
+
+#### Usage
+```
+URI: /node/run/sshc
+Method: TBA
+```
+
+Example:
+```sh
+```
+
+Response:
+```
+```
+	
+### Run SOCKSS
+Runs (starts) the Skywire `sockss` (Socks Server) application on the Node.
+
+#### Usage
+```
+URI: /node/run/sockss
+Method: TBA
+```
+
+Example:
+```sh
+```
+
+Response:
+```
+```
+
+### Run SOCKSC
+Runs (starts) the Skywire `socksc` (Socks Client) application on the Node.
+
+#### Usage
+```
+URI: /node/run/socksc
+Method: TBA
+```
+
+Example:
+```sh
+```
+
+Response:
+```
+```
+
+### Run UPDATE
+Runs (starts) the Skywire software update process. Use `/node/run/checkUpdate` to check if a new software version is avaiable first.
+
+#### Usage
+```
+URI: /node/run/update
+Method: TBA
+```
+
+Example:
+```sh
+```
+
+Response:
+```
+```
+
+### Run Check Update
+Runs (starts) the Skywire software update check. Used to check if a new version of Skywire is available. Use `/node/run/update` to perform the update.
+
+#### Usage
+```
+URI: /node/run/checkUpdate
+Method: TBA
+```
+
+Example:
+```sh
+```
+
+Response:
+```
+```
+	
+### Set Node Config
+#### Usage
+```
+URI: /node/run/setNodeConfig
+Method: TBA
+```
+
+Example:
+```sh
+```
+
+Response:
+```
+```
+
+### Update Node
+#### Usage
+```
+URI: /node/run/updateNode
+Method: TBA
+```
+
+Example:
+```sh
+```
+
+Response:
+```
+```
+	
+### Run Shell
+#### Usage
+```
+URI: /node/run/runShell
+Method: TBA
+```
+
+Example:
+```sh
+```
+
+Response:
+```
+```
+	
+### Run Command
+#### Usage
+```
+URI: /node/run/runCmd
+Method: TBA
+```
+
+Example:
+```sh
+```
+
+Response:
+```
+```
+	
+### Get Shell Output
+#### Usage
+```
+URI: /node/run/getShellOutput
+Method: TBA
+```
+
+Example:
+```sh
+```
+
+Response:
+```
+```
+
+### Serach Services
+#### Usage
+```
+URI: /node/run/searchServices
+Method: TBA
+```
+
+Example:
+```sh
+```
+
+Response:
+```
+```
+
+### Search Services Results
+#### Usage
+```
+URI: /node/run/searchServicesResults
+Method: TBA
+```
+
+Example:
+```sh
+```
+
+Response:
+```
+```
+
+### Get Auto Start Config
+#### Usage
+```
+URI: /node/run/getAutoStartConfig
+Method: TBA
+```
+
+Example:
+```sh
+```
+
+Response:
+```
+```
+TBA
+
+### Set Auto Start Config
+#### Usage
+```
+URI: /node/run/setAutoStartConfig
+Method: TBA
+```
+
+Example:
+```sh
+```
+
+Response:
+```
+```
+
+### Close Application
+#### Usage
+```
+URI: /node/run/closeApp
+Method: TBA
+```
+
+Example:
+```sh
+```
+
+Response:
+```
+```
+
+### Run TERM
+#### Usage
+```
+URI: /node/run/term
+Method: Get
+```
+
+Example:
+```sh
+```
+
+Response:
+```
+```


### PR DESCRIPTION
Partial (work in progress) documentation of both the Skywire Manager and Node APIs, with `curl` examples.

Added folder `docs/apis` which contains the ManagerAPI.md and NodeAPI.md.
Updated the project Readme.md. Added a section to the table of contents for Developers Guide with sub-items linking to Manager and Node API docs.

The API documentation is incomplete, but working on the basis that some is better than none.