### PR TITLE
fixed Dockerfile, updated compose and docker image usage in README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,8 @@ ENV DATA_DIR=/root/.skywire
 
 #USER skywire
 
-# copy binaries and assets
-COPY --from=build-go /go/bin/* /usr/bin/
+# copy binaries and asset
+COPY --from=build-go /go/bin/* /bin/
 COPY --from=build-go /go/bin/sockss .
 COPY --from=build-node /home/node/net/skycoin-messenger/monitor/web/dist-manager /usr/local/skycoin/net/skycoin-messenger/monitor/web/dist-manager
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ docker run -ti --rm \
       -manager-address skywire-manager:5998 \
       -manager-web skywire-manager:8000 \
       -address :5000 \
-      -web-port :6001
+      -web-port :6001 \
+      -discovery-address discovery.skycoin.net:5999-034b1cd4ebad163e457fb805b3ba43779958bba49f2c5e1e8b062482904bacdb68
 ```
 
 ### Docker Compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     image: skycoin/skywire
     volumes:
       - skywire-data:/root/.skywire
-    command: node -connect-manager -manager-address manager:5998 -manager-web manager:8000 -address :5000 -web-port :6001
+    command: node -connect-manager -manager-address manager:5998 -manager-web manager:8000 -address :5000 -web-port :6001 -discovery-address discovery.skycoin.net:5999-034b1cd4ebad163e457fb805b3ba43779958bba49f2c5e1e8b062482904bacdb68
     ports:
       - 5000:5000
       - 6001:6001


### PR DESCRIPTION
The Docker image when using a slave node was not working due to the binary `sockss` not being placed in the right route.

The Docker image should also be updated, has been the same since 5 months ago.