### PR TITLE
[docker] refs #111 - Disable builds for ARM v5 and v7

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -2,7 +2,7 @@
 docker build -f $DOCKERFILE_PATH -t $IMAGE_NAME .
 
 # ARM builds
-docker build --build-arg=ARCH=arm --build-arg=GOARM=5 --build-arg=IMAGE_FROM="arm32v5/alpine" -f $DOCKERFILE_PATH -t $DOCKER_REPO:arm32v5 .
+#docker build --build-arg=ARCH=arm --build-arg=GOARM=5 --build-arg=IMAGE_FROM="arm32v5/alpine" -f $DOCKERFILE_PATH -t $DOCKER_REPO:arm32v5 .
 docker build --build-arg=ARCH=arm --build-arg=GOARM=6 --build-arg=IMAGE_FROM="arm32v6/alpine" -f $DOCKERFILE_PATH -t $DOCKER_REPO:arm32v6 .
-docker build --build-arg=ARCH=arm --build-arg=GOARM=7 --build-arg=IMAGE_FROM="arm32v7/alpine" -f $DOCKERFILE_PATH -t $DOCKER_REPO:arm32v7 .
+#docker build --build-arg=ARCH=arm --build-arg=GOARM=7 --build-arg=IMAGE_FROM="arm32v7/alpine" -f $DOCKERFILE_PATH -t $DOCKER_REPO:arm32v7 .
 docker build --build-arg=ARCH=arm64 --build-arg=IMAGE_FROM="arm64v8/alpine" -f $DOCKERFILE_PATH -t $DOCKER_REPO:arm64v8 .


### PR DESCRIPTION
Temporary solution for #111 

Changes :

- Enable the builds for versions supported by `alpine` image
- Disable the rest