### PR TITLE
Issue #100. Address logic error in verifyLogin function in Monitor.go

### DIFF
--- a/pkg/net/skycoin-messenger/monitor/monitor.go
+++ b/pkg/net/skycoin-messenger/monitor/monitor.go
@@ -629,7 +629,7 @@ func (m *Monitor) UpdatePass(w http.ResponseWriter, r *http.Request) (result []b
 		result = []byte("A new password must be provided.")
 		return
 	}
-	if isDefaultPassCleartext(newPass) {
+	if isDefaultPass(newPass) {
 		result = []byte("The default password cannot be used.")
 		return
 	}

--- a/pkg/net/skycoin-messenger/monitor/monitor.go
+++ b/pkg/net/skycoin-messenger/monitor/monitor.go
@@ -619,21 +619,23 @@ func (m *Monitor) UpdatePass(w http.ResponseWriter, r *http.Request) (result []b
 	}
 	oldPass := r.FormValue("oldPass")
 	newPass := r.FormValue("newPass")
-	if len(oldPass) < 4 || len(oldPass) > 20 {
-		result = []byte("Old password length is 4~20.")
+	// Check that the old password was provided. We dont care about its length, as long as its not zero.
+	if len(oldPass) < 1 {
+		result = []byte("Your existing (old) password must be provided.")
 		return
 	}
-	if len(newPass) < 4 || len(newPass) > 20 {
-		result = []byte("New password length is 4~20.")
+	// Check the length of the new password. We dont care about how long the user makes it, as long as its not zero
+	if len(newPass) < 1 {
+		result = []byte("A new password must be provided.")
 		return
 	}
-	if newPass == "1234" {
-		result = []byte("Please do not change the default password.")
+	if isDefaultPassCleartext(newPass) {
+		result = []byte("The default password cannot be used.")
 		return
 	}
 	err = checkPass(oldPass)
 	if err != nil {
-		result = []byte("The original password is wrong, please confirm again and try again.")
+		result = []byte("The original password is wrong, please confirm and try again.")
 		return
 	}
 	err = WriteConfig(&User{Pass: getBcrypt(newPass)}, userPath)
@@ -682,7 +684,7 @@ func verifyLogin(w http.ResponseWriter, r *http.Request, checkDefaultPass bool) 
 		return false
 	}
 	hash := sess.Get("pass")
-	if pass == nil {
+	if hash == nil {
 		http.Error(w, "Unauthorized", http.StatusFound)
 		return false
 	}
@@ -700,7 +702,7 @@ func verifyLogin(w http.ResponseWriter, r *http.Request, checkDefaultPass bool) 
 		http.Error(w, "Unauthorized", http.StatusFound)
 		return false
 	}
-	if !checkDefaultPass && isDefaultPass() {
+	if !checkDefaultPass && userHasDefaultPass() {
 		http.Error(w, "Forced change password", http.StatusTemporaryRedirect)
 		return false
 	}

--- a/pkg/net/skycoin-messenger/monitor/utils.go
+++ b/pkg/net/skycoin-messenger/monitor/utils.go
@@ -1,23 +1,30 @@
 package monitor
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"golang.org/x/crypto/bcrypt"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"time"
-	"encoding/hex"
-	"math/rand"
+
+	"golang.org/x/crypto/bcrypt"
 )
 
+// User struct contains the user configuration, specifically the users
+// hashed password (Pass)
 type User struct {
 	Pass string
 }
 
 var user *User
 
+// readUserCongig will load (read) the User structure from the
+// configuration file specified by path. This function will
+// read the JSON from the configuration file into a User struct
+// and store it in the global variable user.
 func readUserConfig(path string) (user *User, err error) {
 	fb, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -28,6 +35,10 @@ func readUserConfig(path string) (user *User, err error) {
 	return
 }
 
+// WriteConfig stores the JSON respresentation of the User structure
+// within a configuration file in the provided path
+// This function will set directory permissions to 0700 and
+// file permissions to 0600
 func WriteConfig(user *User, path string) (err error) {
 	data, err := json.Marshal(user)
 	if err != nil {
@@ -42,6 +53,11 @@ func WriteConfig(user *User, path string) (err error) {
 	return
 }
 
+// checkPass checks the provided password plaintext against
+// the stored password hash for the user. If the user has not
+// been loaded, it will be loaded from configuration. If the
+// configuration file does not exist, the default password
+// will be assinged to the user and stored in the config
 func checkPass(pass string) (err error) {
 	user, err = readUserConfig(userPath)
 	if err != nil {
@@ -62,13 +78,16 @@ func checkPass(pass string) (err error) {
 	return
 }
 
-//bcrypt pass
+// getBcrypt will return a bcrypt generated password hash from the provided
+// password plaintext. This function currently uses the bcrypt MinCost
+// to generate the hash.
 func getBcrypt(password string) string {
 	hash, _ := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
 	return string(hash)
 }
 
-//match pass
+// matchPassword compares an hashed password (hash) with a possible
+// plaintext version (password) and returns the result as a boolean.
 func matchPassword(hash, password string) bool {
 	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
 	if err == nil {
@@ -77,16 +96,27 @@ func matchPassword(hash, password string) bool {
 	return false
 }
 
-func isDefaultPass() bool {
+// userHasDefaultPass checks if the currently loaded User structure uses
+// the default password ("1234") or not.
+// Note: if the global variable user has not been loaded yet, this function
+// will cause it to be loaded from the configuration file.
+func userHasDefaultPass() bool {
 	if user == nil {
 		user, _ = readUserConfig(userPath)
 	}
 	return matchPassword(user.Pass, "1234")
 }
 
+// getRandomString returns a randomly generated string of the requested length (len)
 func getRandomString(len int) string {
 	bytes := make([]byte, len)
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	r.Read(bytes)
 	return hex.EncodeToString(bytes)
+}
+
+// isDefaultPass checks the provided password cleartext string (pass) against
+// the hard coded default password string ("1234") and returns the result.
+func isDefaultPass(pass string) bool {
+	return pass == "1234"
 }


### PR DESCRIPTION
Changes to `monitor.go`:
- `UpdatePass` function:
  - Remove password length check restrictions. Previously the password would be rejected if its length was < 4 or > 20. Now there is no maximum restriction on the length of the password, and the minimum length is > 0 (i.e. 1 character).
  - Updated the error messages returned by the function.
  - Use new `isDefaultPass` (defined in utils.go) to check if the users password is the default ("1234")
  - Use newly renamed `userHasDefaultPass` function to determine if the user has the default password. This function was previously named `isDefaultPass`

- `verifyLogin` function:
  - Correct logic error. Swap use of `pass` with `hash` variable.

Changes to `utils.go`:
- Add comments to each function.
- Renamed `isDefaultPass` function to `userHasDefaultPass`.
- Added new function `isDefaultPass` to check newly provided user plaintext password against the default password "1234"

Was unable to build successfully within my personal fork (without using `dep` to rebuild all project dependencies - which seemed to work, but unsure of the consequences). Performed testing against a local branch of the official `skywire` repo. Tests conducted via the Manager Web GUI.

Please let me know if there are any change that should be made and/or additional testing needed.