### PR TITLE
Actualize readme 223

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DOCKER_NETWORK?=SKYNET
 DOCKER_NODE?=SKY01
 DOCKER_OPTS?=GO111MODULE=on GOOS=linux # go options for compiling for docker container
 
-build: dep apps bin
+build: dep host-apps bin
 
 clean:
 	rm -rf ./apps
@@ -38,8 +38,6 @@ test: ## Run tests for net
 	${OPTS} go test -race -tags no_ci -cover -timeout=5m ./internal/...
 	${OPTS} go test -race -tags no_ci -cover -timeout=5m ./pkg/...
 
-
-build: host-apps bin
 
 # Apps 
 host-apps: 

--- a/README.md
+++ b/README.md
@@ -275,10 +275,6 @@ Default value: "GO111MODULE=on GOOS=linux"
 #### 1. Get Public Key of node
 
 ```bash
-# you need `jq` (https://stedolan.github.io/jq/) for this:
-$ cat ./node/skywire.json |jq -r ".node.static_public_key" 
-# 029be6fa68c13e9222553035cc1636d98fb36a888aa569d9ce8aa58caa2c651b45
-# or without `jq`:
 $ cat ./node/skywire.json|grep static_public_key |cut -d ':' -f2 |tr -d '"'','' '
 # 029be6fa68c13e9222553035cc1636d98fb36a888aa569d9ce8aa58caa2c651b45
 # or just:
@@ -286,14 +282,20 @@ $ cat ./node/PK # this file is created during `make docker-volume`
 # 029be6fa68c13e9222553035cc1636d98fb36a888aa569d9ce8aa58caa2c651b45
 ```
 
-#### 2. Open in browser containerized `chat` application
+#### 2. Get an IP of node
 
 ```bash
-# you need `jq` (https://stedolan.github.io/jq/) for this:
-$ firefox http://$(docker inspect SKY01 |jq -r  ".[0].NetworkSettings.Networks.SKYNET.IPAddress"):8000
+$ docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' SKY01
+# 192.168.112
 ```
 
-#### 3. Create new dockerize `skywire-nodes`
+#### 3. Open in browser containerized `chat` application
+
+```bash
+$ firefox http://$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' SKY01):8000  
+```
+
+#### 4. Create new dockerize `skywire-nodes`
 
 In case you need more dockerized nodes or maybe it's needed to customize node
 let's look how to create new node.
@@ -301,7 +303,7 @@ let's look how to create new node.
 ```bash
 # 1. We need a folder for docker volume
 $ mkdir /tmp/SKYNODE
-# 2. compile  `skywire-node` 
+# 2. compile  `skywire-node`
 $ GO111MODULE=on GOOS=linux go build -o /tmp/SKYNODE/skywire-node ./cmd/skywire-node
 # 3. compile apps
 $ GO111MODULE=on GOOS=linux go build -o /tmp/SKYNODE/apps/chat.v1.0 ./cmd/apps/chat

--- a/README.md
+++ b/README.md
@@ -38,23 +38,23 @@ $ git clone https://github.com/skycoin/skywire
 $ cd skywire
 $ git checkout mainnet
 
+
+# Build
+
+```bash
+make # this will install all dependencies and build binaries
+```
+
 # Install skywire-node, skywire-cli, manager-node and therealssh-cli
-$ GO111MODULE=on go install ./cmd/skywire-node ./cmd/skywire-cli ./cmd/manager-node ./cmd/therealssh-cli
 
-# Setup run folder.
-mkdir skywire
-mkdir apps
+```bash
+make install
+```
 
-# Build apps.
-$ GO111MODULE=on go build -o ./apps/chat.v1.0 ./cmd/apps/chat
-$ GO111MODULE=on go build -o ./apps/helloworld.v1.0 ./cmd/apps/helloworld
-$ GO111MODULE=on go build -o ./apps/therealproxy.v1.0 ./cmd/apps/therealproxy
-$ GO111MODULE=on go build -o ./apps/therealproxy-client.v1.0  ./cmd/apps/therealproxy-client
-$ GO111MODULE=on go build -o ./apps/therealssh.v1.0  ./cmd/apps/therealssh
-$ GO111MODULE=on go build -o ./apps/therealssh-client.v1.0  ./cmd/apps/therealssh-client
+# Generate default json config
 
-# Generate default json config.
-$ skywire-cli config
+```bash
+skywire-cli config
 ```
 
 ### Run `skywire-node`
@@ -66,6 +66,12 @@ $ skywire-cli config
 $ skywire-node skywire.json
 ```
 
+### Run `skywire-node` in docker container
+
+```bash
+make node
+```
+
 ### Run `skywire-cli`
 
 The `skywire-cli` tool is used to control the `skywire-node`. Refer to the help menu for usage:
@@ -74,25 +80,36 @@ The `skywire-cli` tool is used to control the `skywire-node`. Refer to the help 
 $ skywire-cli -h
 
 # Command Line Interface for skywire
-# 
+#
 # Usage:
 #   skywire-cli [command]
-# 
+#
 # Available Commands:
-#   app                 app management operations
-#   config              Generate default config file
-#   help                Help about any command
-#   messaging-discovery manage operations with messaging discovery api
-#   route-finder        manage operations with route finder api
-#   routing-rules       manages operations with routing rules
-#   transport-discovery manage operations with transport discovery api
-#   transports          manages transports related operations
-# 
+#   add-rule          adds a new routing rule
+#   add-transport     adds a new transport
+#   apps              lists apps running on the node
+#   config            Generate default config file
+#   find-routes       lists available routes between two nodes via route finder service
+#   find-transport    finds and lists transport(s) of given transport ID or edge public key from transport discovery
+#   help              Help about any command
+#   list-rules        lists the local node's routing rules
+#   list-transports   lists the available transports with optional filter flags
+#   messaging         manage operations with messaging services
+#   rm-rule           removes a routing rule via route ID key
+#   rm-transport      removes transport with given id
+#   rule              returns a routing rule via route ID key
+#   set-app-autostart sets the autostart flag for an app of given name
+#   start-app         starts an app of given name
+#   stop-app          stops an app of given name
+#   transport         returns summary of given transport by id
+#   transport-types   lists transport types used by the local node
+#
 # Flags:
 #   -h, --help         help for skywire-cli
 #       --rpc string   RPC server address (default "localhost:3435")
-# 
+#
 # Use "skywire-cli [command] --help" for more information about a command.
+
 ```
 
 ### Apps
@@ -112,7 +129,7 @@ Transports can be established via the `skywire-cli`.
 
 ```bash
 # Establish transport to `0276ad1c5e77d7945ad6343a3c36a8014f463653b3375b6e02ebeaa3a21d89e881`.
-$ skywire-cli transports add 0276ad1c5e77d7945ad6343a3c36a8014f463653b3375b6e02ebeaa3a21d89e881
+$ skywire-cli add-transport 0276ad1c5e77d7945ad6343a3c36a8014f463653b3375b6e02ebeaa3a21d89e881
 
 # List established transports.
 $ skywire-cli transports list
@@ -146,4 +163,4 @@ func (app *App) Close() error {}
 
 ## Updater
 
-This software comes with an updater, which is located in this repo: https://github.com/skycoin/skywire-updater. Follow the instructions in the README.md for further information. It can be used with a CLI for now and will be usable with the manager interface. 
+This software comes with an updater, which is located in this repo: https://github.com/skycoin/skywire-updater. Follow the instructions in the README.md for further information. It can be used with a CLI for now and will be usable with the manager interface.

--- a/README.md
+++ b/README.md
@@ -37,18 +37,27 @@ Skywire requires a version of [golang](https://golang.org/) with [go modules](ht
 $ git clone https://github.com/skycoin/skywire
 $ cd skywire
 $ git checkout mainnet
-
-
 # Build
+$ make # installs all dependencies, build binaries and apps
+```
+
+#### Note: Environment variable OPTS
+
+Build can be customized with environment variable `OPTS` with default value `GO111MODULE=on`
+
+E.g.
 
 ```bash
-make # this will install all dependencies and build binaries
+$ export OPTS="GO111MODULE=on GOOS=darwin"
+$ make
+# or
+$ OPTS="GSO111MODULE=on GOOS=linux GOARCH=arm" make
 ```
 
 # Install skywire-node, skywire-cli, manager-node and therealssh-cli
 
 ```bash
-make install
+$ make install  # compiles and installs all binaries
 ```
 
 # Generate default json config
@@ -164,3 +173,65 @@ func (app *App) Close() error {}
 ## Updater
 
 This software comes with an updater, which is located in this repo: https://github.com/skycoin/skywire-updater. Follow the instructions in the README.md for further information. It can be used with a CLI for now and will be usable with the manager interface.
+
+## Running skywire in docker containers
+
+There are two make goals for running in development environment dockerized `skywire-node`.
+
+### Run dockerized `skywire-node`
+
+```bash
+$ make node
+```
+
+This will:
+
+- create docker image `skywire-runner` for running `skywire-node`
+- create docker network `SKYNET` (can be customized)
+- create docker volume ./node with linux binaries and apps
+- create container  `SKY01` and starts it (can be customized)
+
+### Refresh and restart `SKY01`
+
+```bash
+$ make refresh-node
+```
+
+This will:
+
+ - stops running node
+ - recompiles `skywire-node` for container
+ - start node again
+
+### Customization of dockers
+
+#### 1. DOCKER_IMAGE
+
+Docker image for running `skywire-node`.
+
+Default value: `skywire-runner` (built with `make docker-image`)
+
+Other images can be used.
+E.g.
+
+```bash
+DOCKER_IMAGE=golang make node #buildpack-deps:stretch-scm is OK too
+```
+
+#### 2.DOCKER_NETWORK
+
+Name of virtual network for `skywire-node`
+
+Default value: SKYNET
+
+#### 3. DOCKER_NODE
+
+Name of container for `skywire-node`
+
+Default value: SKY01
+
+#### 4. DOCKER_OPTS
+
+`go build` options for binaries and apps in container.
+
+Default value: "GO111MODULE=on GOOS=linux"


### PR DESCRIPTION
1. Simplified sections of build, install instructions
2. Described usage of dockerized `skywire-node`
3. Actualized sections with skywire-cli
4. Fixed typo in Makefile - there was double declaration of `make build`
