### PR TITLE
sort transports listed by skywire-cli list-transports command

### DIFF
--- a/cmd/skywire-cli/commands/transport.go
+++ b/cmd/skywire-cli/commands/transport.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"text/tabwriter"
 	"time"
+	"sort"
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
@@ -155,6 +156,7 @@ func init() {
 }
 
 func printTransports(tps ...*node.TransportSummary) {
+	sortTransports(tps...)
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 5, ' ', tabwriter.TabIndent)
 	_, err := fmt.Fprintln(w, "type\tid\tlocal\tremote")
 	catch(err)
@@ -175,4 +177,10 @@ func printTransportEntries(entries ...*transport.EntryWithStatus) {
 		catch(err)
 	}
 	catch(w.Flush())
+}
+
+func sortTransports(tps ...*node.TransportSummary) {
+	sort.Slice(tps, func(i, j int) bool {
+		return tps[i].ID.String() < tps[j].ID.String()
+	})
 }

--- a/cmd/skywire-cli/commands/transport.go
+++ b/cmd/skywire-cli/commands/transport.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"text/tabwriter"
 	"time"
-	"sort"
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"


### PR DESCRIPTION
fixes #250 
I have added a method that sorts transports by transport-id before printing them out