### PR TITLE
fixed ack issue

### DIFF
--- a/internal/ioutil/ack.go
+++ b/internal/ioutil/ack.go
@@ -192,6 +192,7 @@ func (arw *AckReadWriter) confirm(seq byte, hash []byte) {
 
 	if ack.hash != rcvHash {
 		ack.errChan <- errors.New("invalid CRC")
+		return
 	}
 
 	ack.errChan <- nil

--- a/internal/ioutil/ack.go
+++ b/internal/ioutil/ack.go
@@ -142,7 +142,7 @@ func (arw *AckReadWriter) serveLoop() {
 				break
 			}
 
-			go arw.confirm(data[1], data[2:34])
+			arw.confirm(data[1], data[2:34])
 			data = data[34:]
 		}
 


### PR DESCRIPTION
Closes #225.

There is a modification to data buffer in line https://github.com/skycoin/skywire/blob/b85aee6f251fa7aa5d8a6641f64b8c4bb11f2ce6/internal/ioutil/ack.go#L146

The previous line was before launched in a goroutine, which often executed after such modification, leading to a comparison between wrong ack's, and thus the reported failure.

A similar behavior can be achieved by adding a wait group and keeping the `confirm` function executing in a goroutine, but current implementation should not have a noticeable performance impact.