### PR TITLE
Detect unstable tests in mainnet branch

### DIFF
--- a/ci_scripts/run-internal-tests.sh
+++ b/ci_scripts/run-internal-tests.sh
@@ -1,0 +1,34 @@
+# commit a70894c8c4223424151cdff7441b1fb2e6bad309
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/httpauth -run TestClient >> ./logs/internal/TestClient.log
+
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/ioutil	-run TestAckReadWriter >> ./logs/internal/TestAckReadWriter.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/ioutil	-run TestAckReadWriterCRCFailure >> ./logs/internal/TestAckReadWriterCRCFailure.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/ioutil	-run TestAckReadWriterFlushOnClose >> ./logs/internal/TestAckReadWriterFlushOnClose.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/ioutil	-run TestAckReadWriterPartialRead >> ./logs/internal/TestAckReadWriterPartialRead.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/ioutil	-run TestAckReadWriterReadError >> ./logs/internal/TestAckReadWriterReadError.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/ioutil	-run TestLenReadWriter >> ./logs/internal/TestLenReadWriter.log
+
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/noise -run TestRPCClientDialer >> ./logs/internal/TestRPCClientDialer.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/noise -run TestConn >> ./logs/internal/TestConn.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/noise -run TestListener >> ./logs/internal/TestListener.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/noise -run TestKKAndSecp256k1 >> ./logs/internal/TestKKAndSecp256k1.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/noise -run TestXKAndSecp256k1 >> ./logs/internal/TestXKAndSecp256k1.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/noise -run TestReadWriterKKPattern >> ./logs/internal/TestReadWriterKKPattern.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/noise -run TestReadWriterXKPattern >> ./logs/internal/TestReadWriterXKPattern.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/noise -run TestReadWriterConcurrentTCP >> ./logs/internal/TestReadWriterConcurrentTCP.log
+
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/therealproxy -run TestProxy >> ./logs/internal/TestProxy.log
+
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/therealssh  -run TestListAuthoriser >> ./logs/internal/TestListAuthoriser.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/therealssh  -run TestFileAuthoriser >> ./logs/internal/TestFileAuthoriser.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/therealssh  -run TestChannelServe >> ./logs/internal/TestChannelServe.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/therealssh  -run TestChannelSendWrite >> ./logs/internal/TestChannelSendWrite.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/therealssh  -run TestChannelRead >> ./logs/internal/TestChannelRead.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/therealssh  -run TestChannelRequest >> ./logs/internal/TestChannelRequest.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/therealssh  -run TestChannelServeSocket >> ./logs/internal/TestChannelServeSocket.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/therealssh  -run TestClientOpenChannel >> ./logs/internal/TestClientOpenChannel.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/therealssh  -run TestClientHandleResponse >> ./logs/internal/TestClientHandleResponse.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/therealssh  -run TestClientHandleData >> ./logs/internal/TestClientHandleData.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/therealssh  -run TestServerOpenChannel >> ./logs/internal/TestServerOpenChannel.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/therealssh  -run TestServerHandleRequest >> ./logs/internal/TestServerHandleRequest.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/therealssh  -run TestServerHandleData >> ./logs/internal/TestServerHandleData.log

--- a/ci_scripts/run-pkg-tests.sh
+++ b/ci_scripts/run-pkg-tests.sh
@@ -1,0 +1,121 @@
+# commit a70894c8c4223424151cdff7441b1fb2e6bad309
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/app  -run TestAppDial >> ./logs/pkg/TestAppDial.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/app  -run TestAppAccept >> ./logs/pkg/TestAppAccept.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/app  -run TestAppWrite >> ./logs/pkg/TestAppWrite.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/app  -run TestAppRead >> ./logs/pkg/TestAppRead.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/app  -run TestAppSetup >> ./logs/pkg/TestAppSetup.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/app  -run TestAppCloseConn >> ./logs/pkg/TestAppCloseConn.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/app  -run TestAppClose >> ./logs/pkg/TestAppClose.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/app  -run TestAppCommand >> ./logs/pkg/TestAppCommand.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/app  -run TestPipeConn >> ./logs/pkg/TestPipeConn.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/app  -run TestProtocol >> ./logs/pkg/TestProtocol.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/app  -run TestProtocolParallel >> ./logs/pkg/TestProtocolParallel.log
+ 
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m  github.com/skycoin/skywire/pkg/cipher -run TestPubKeyString >> ./logs/pkg/TestPubKeyString.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m  github.com/skycoin/skywire/pkg/cipher -run TestPubKeyTextMarshaller >> ./logs/pkg/TestPubKeyTextMarshaller.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m  github.com/skycoin/skywire/pkg/cipher -run TestPubKeyBinaryMarshaller >> ./logs/pkg/TestPubKeyBinaryMarshaller.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m  github.com/skycoin/skywire/pkg/cipher -run TestSecKeyString >> ./logs/pkg/TestSecKeyString.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m  github.com/skycoin/skywire/pkg/cipher -run TestSecKeyTextMarshaller >> ./logs/pkg/TestSecKeyTextMarshaller.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m  github.com/skycoin/skywire/pkg/cipher -run TestSecKeyBinaryMarshaller >> ./logs/pkg/TestSecKeyBinaryMarshaller.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m  github.com/skycoin/skywire/pkg/cipher -run TestSigString >> ./logs/pkg/TestSigString.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m  github.com/skycoin/skywire/pkg/cipher -run TestSigTextMarshaller >> ./logs/pkg/TestSigTextMarshaller.log
+
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m  github.com/skycoin/skywire/pkg/manager -run TestNewNode >> ./logs/pkg/TestNewNode.log
+
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging -run TestChannelRead >> ./logs/pkg/TestChannelRead.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging -run TestChannelWrite >> ./logs/pkg/TestChannelWrite.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging -run TestChannelClose >> ./logs/pkg/TestChannelClose.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging -run TestClientConnectInitialServers >> ./logs/pkg/TestClientConnectInitialServers.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging -run TestClientDial >> ./logs/pkg/TestClientDial.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging -run TestHandshakeFrame >> ./logs/pkg/TestHandshakeFrame.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging -run TestHandshake >> ./logs/pkg/TestHandshake.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging -run TestHandshakeInvalidResponder >> ./logs/pkg/TestHandshakeInvalidResponder.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging -run TestHandshakeInvalidInitiator >> ./logs/pkg/TestHandshakeInvalidInitiator.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging -run TestNewConn >> ./logs/pkg/TestNewConn.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging -run TestNewPool >> ./logs/pkg/TestNewPool.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging -run TestPool_Range >> ./logs/pkg/TestPool_Range.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging -run TestPool_All >> ./logs/pkg/TestPool_All.log
+
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging-discovery/client -run TestNewMockGetAvailableServers>> ./logs/pkg/TestNewMockGetAvailableServers.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging-discovery/client -run TestNewMockEntriesEndpoint>> ./logs/pkg/TestNewMockEntriesEndpoint.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging-discovery/client -run TestNewMockSetEntriesEndpoint>> ./logs/pkg/TestNewMockSetEntriesEndpoint.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging-discovery/client -run TestNewMockUpdateEntriesEndpoint>> ./logs/pkg/TestNewMockUpdateEntriesEndpoint.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging-discovery/client -run TestNewMockUpdateEntrySequence>> ./logs/pkg/TestNewMockUpdateEntrySequence.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging-discovery/client -run TestNewClientEntryIsValid>> ./logs/pkg/TestNewClientEntryIsValid.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging-discovery/client -run TestVerifySignature>> ./logs/pkg/TestVerifySignature.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging-discovery/client -run TestValidateRightEntry>> ./logs/pkg/TestValidateRightEntry.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging-discovery/client -run TestValidateNonKeysEntry>> ./logs/pkg/TestValidateNonKeysEntry.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging-discovery/client -run TestValidateNonClientNonServerEntry>> ./logs/pkg/TestValidateNonClientNonServerEntry.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging-discovery/client -run TestValidateNonSignedEntry>> ./logs/pkg/TestValidateNonSignedEntry.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging-discovery/client -run TestValidateIteration>> ./logs/pkg/TestValidateIteration.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging-discovery/client -run TestValidateIterationEmptyClient>> ./logs/pkg/TestValidateIterationEmptyClient.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging-discovery/client -run TestValidateIterationWrongSequence>> ./logs/pkg/TestValidateIterationWrongSequence.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging-discovery/client -run TestValidateIterationWrongTime>> ./logs/pkg/TestValidateIterationWrongTime.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/messaging-discovery/client -run TestCopy>> ./logs/pkg/TestCopy.log
+
+
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/node	 -run TestMessagingDiscovery >> ./logs/pkg/TestMessagingDiscovery.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/node	 -run TestTransportDiscovery >> ./logs/pkg/TestTransportDiscovery.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/node	 -run TestTransportLogStore >> ./logs/pkg/TestTransportLogStore.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/node	 -run TestRoutingTable >> ./logs/pkg/TestRoutingTable.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/node	 -run TestAppsConfig >> ./logs/pkg/TestAppsConfig.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/node	 -run TestAppsDir >> ./logs/pkg/TestAppsDir.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/node	 -run TestLocalDir >> ./logs/pkg/TestLocalDir.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/node	 -run TestNewNode >> ./logs/pkg/TestNewNode.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/node	 -run TestNodeStartClose >> ./logs/pkg/TestNodeStartClose.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/node	 -run TestNodeSpawnApp >> ./logs/pkg/TestNodeSpawnApp.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/node	 -run TestNodeSpawnAppValidations >> ./logs/pkg/TestNodeSpawnAppValidations.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/node	 -run TestListApps >> ./logs/pkg/TestListApps.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/node	 -run TestStartStopApp >> ./logs/pkg/TestStartStopApp.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/node	 -run TestRPC >> ./logs/pkg/TestRPC.log
+
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestAppManagerInit >> ./logs/pkg/TestAppManagerInit.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestAppManagerSetupLoop >> ./logs/pkg/TestAppManagerSetupLoop.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestAppManagerCloseLoop >> ./logs/pkg/TestAppManagerCloseLoop.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestAppManagerForward >> ./logs/pkg/TestAppManagerForward.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestManagedRoutingTableCleanup >> ./logs/pkg/TestManagedRoutingTableCleanup.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestPortManager >> ./logs/pkg/TestPortManager.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestRouteManagerGetRule >> ./logs/pkg/TestRouteManagerGetRule.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestRouteManagerRemoveLoopRule >> ./logs/pkg/TestRouteManagerRemoveLoopRule.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestRouteManagerAddRemoveRule >> ./logs/pkg/TestRouteManagerAddRemoveRule.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestRouteManagerDeleteRules >> ./logs/pkg/TestRouteManagerDeleteRules.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestRouteManagerConfirmLoop >> ./logs/pkg/TestRouteManagerConfirmLoop.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestRouteManagerLoopClosed >> ./logs/pkg/TestRouteManagerLoopClosed.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestRouterForwarding >> ./logs/pkg/TestRouterForwarding.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestRouterAppInit >> ./logs/pkg/TestRouterAppInit.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestRouterApp >> ./logs/pkg/TestRouterApp.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestRouterLocalApp >> ./logs/pkg/TestRouterLocalApp.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestRouterSetup >> ./logs/pkg/TestRouterSetup.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestRouterSetupLoop >> ./logs/pkg/TestRouterSetupLoop.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestRouterSetupLoopLocal >> ./logs/pkg/TestRouterSetupLoopLocal.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestRouterCloseLoop >> ./logs/pkg/TestRouterCloseLoop.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestRouterCloseLoopOnAppClose >> ./logs/pkg/TestRouterCloseLoopOnAppClose.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestRouterCloseLoopOnRouterClose >> ./logs/pkg/TestRouterCloseLoopOnRouterClose.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/router -run  TestRouterRouteExpiration >> ./logs/pkg/TestRouterRouteExpiration.log
+
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/routing -run TestBoltDBRoutingTable >> ./logs/pkg/TestBoltDBRoutingTable.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/routing -run TestMakePacket >> ./logs/pkg/TestMakePacket.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/routing -run TestRoutingTable >> ./logs/pkg/TestRoutingTable.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/routing -run TestAppRule >> ./logs/pkg/TestAppRule.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/routing -run TestForwardRule >> ./logs/pkg/TestForwardRule.log
+
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/setup -run TestNewProtocol >> ./logs/pkg/TestNewProtocol.log
+
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/transport -run TestSettlementHandshake >> ./logs/pkg/TestSettlementHandshake.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/transport -run TestSettlementHandshakeInvalidSig >> ./logs/pkg/TestSettlementHandshakeInvalidSig.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/transport -run TestSettlementHandshakePrivate >> ./logs/pkg/TestSettlementHandshakePrivate.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/transport -run TestSettlementHandshakeExistingTransport >> ./logs/pkg/TestSettlementHandshakeExistingTransport.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/transport -run TestValidateEntry >> ./logs/pkg/TestValidateEntry.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/transport -run TestInMemoryTransportLogStore >> ./logs/pkg/TestInMemoryTransportLogStore.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/transport -run TestFileTransportLogStore >> ./logs/pkg/TestFileTransportLogStore.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/transport -run TestTransportManager >> ./logs/pkg/TestTransportManager.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/transport -run TestTransportManagerReEstablishTransports >> ./logs/pkg/TestTransportManagerReEstablishTransports.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/transport -run TestTransportManagerLogs >> ./logs/pkg/TestTransportManagerLogs.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/transport -run TestTCPFactory >> ./logs/pkg/TestTCPFactory.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/transport -run TestFilePKTable >> ./logs/pkg/TestFilePKTable.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/transport-discovery/client -run TestClientAuth >> ./logs/pkg/TestClientAuth.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/transport-discovery/client -run TestRegisterTransportResponses >> ./logs/pkg/TestRegisterTransportResponses.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/transport-discovery/client -run TestRegisterTransports >> ./logs/pkg/TestRegisterTransports.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/transport-discovery/client -run TestGetTransportByID >> ./logs/pkg/TestGetTransportByID.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/transport-discovery/client -run TestGetTransportsByEdge >> ./logs/pkg/TestGetTransportsByEdge.log
+go clean -testcache &> /dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/pkg/transport-discovery/client -run TestUpdateStatuses >> ./logs/pkg/TestUpdateStatuses.log

--- a/docs/Tests.Detection-of-unstable-tests.md
+++ b/docs/Tests.Detection-of-unstable-tests.md
@@ -1,0 +1,139 @@
+# Tests. Detection of unstable tests
+
+## Synopsys
+
+This document describe procedure to detect tests that FAILs with some probability, e.g. 10-15% of runs.
+
+Such tests are questionable themselves and they add instability of CI builds.
+
+## Step-by-step procedure
+
+### 1. Create list of tests
+
+Use:
+
+```bash
+go test ./pkg/... -list "Test*|Example*" > ./logs/list-of-pkg-tests.txt  # use another path or filename if you wish
+go test ./internal/... -list "Test*|Example*" > ./logs/list-of-internal-tests.txt
+```
+
+You will get output simlar to:
+
+```text
+TestClient
+ok  	github.com/skycoin/skywire/internal/httpauth	0.043s
+?   	github.com/skycoin/skywire/internal/httputil	[no test files]
+TestAckReadWriter
+TestAckReadWriterCRCFailure
+TestAckReadWriterFlushOnClose
+TestAckReadWriterPartialRead
+TestAckReadWriterReadError
+TestLenReadWriter
+ok  	github.com/skycoin/skywire/internal/ioutil	0.049s
+```
+
+Filter lines with `[no test files]`.
+
+Transform this output to:
+
+```bash
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/httpauth -run TestClient >> ./logs/internal/TestClient.log
+
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/ioutil	-run TestAckReadWriter  >>./logs/internal/TestAckReadWriter.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/ioutil	-run TestAckReadWriterCRCFailure  >>./logs/internal/TestAckReadWriterCRCFailure.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/ioutil	-run TestAckReadWriterFlushOnClose  >>./logs/internal/TestAckReadWriterFlushOnClose.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/ioutil	-run TestAckReadWriterPartialRead  >>./logs/internal/TestAckReadWriterPartialRead.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/ioutil	-run TestAckReadWriterReadError  >>./logs/internal/TestAckReadWriterReadError.log
+go clean -testcache &>/dev/null || go test -race -tags no_ci -cover -timeout=5m github.com/skycoin/skywire/internal/ioutil	-run TestLenReadWriter  >>./logs/internal/TestLenReadWriter.log
+```
+
+Notes:
+
+1. `go clean -testcache` - is essential. If ommitted - you will get cached results
+2. `-cover` - gives valueable information when test "hangs": coverage will vary on `ok` and `FAILS`
+3. `-race` - valueable too
+4. `-tags no_ci` - to exclude integration tests
+
+### 2. Collect statistics
+
+Most time-consuming step but it does not require any interaction.
+
+Run produced script(s) multiple times.
+
+E.g. ~20 cycles can be considered "good enough" to find unstable tests.
+And ~100 cycles  to ensure instability.
+
+```sh
+loop -n 100 "bash ./ci_scripts/run-internal-tests.sh" # use any looping method at your disposal
+loop -n 100 "bash ./ci_scripts/run-pkg-tests.sh"
+```
+
+### 3. Analyse
+
+```sh
+grep "FAIL" ./logs/internal/*.log
+grep "FAIL" ./logs/pkg/*.log
+```
+
+If you see something like:
+
+```sh
+$ grep "FAIL" ./logs/pkg/*.log
+# ./logs/pkg/TestClientConnectInitialServers.log:FAIL     github.com/skycoin/skywire/pkg/messaging        300.838s
+# ./logs/pkg/TestClientConnectInitialServers.log:FAIL     github.com/skycoin/skywire/pkg/messaging        300.849s
+# ./logs/pkg/TestClientConnectInitialServers.log:FAIL     github.com/skycoin/skywire/pkg/messaging        300.844s
+# ./logs/pkg/TestClientConnectInitialServers.log:FAIL     github.com/skycoin/skywire/pkg/messaging        300.849s
+```
+
+(note  300s for FAILs)
+
+And:
+
+```sh
+$ grep "coverage" ./logs/pkg/TestClientConnectInitialServers.log  
+# ok      github.com/skycoin/skywire/pkg/messaging        3.049s  coverage: 39.5% of statements
+# coverage: 38.0% of statements
+# ok      github.com/skycoin/skywire/pkg/messaging        3.072s  coverage: 39.5% of statements
+# ok      github.com/skycoin/skywire/pkg/messaging        3.073s  coverage: 39.5% of statements
+# ok      github.com/skycoin/skywire/pkg/messaging        3.071s  coverage: 39.5% of statements
+# ok      github.com/skycoin/skywire/pkg/messaging        3.050s  coverage: 39.5% of statements
+# coverage: 38.0% of statements
+```
+
+(note varying coverage)
+
+You have found unstable test.
+
+### 4. Act
+
+Either fix it or tag it with `no_ci` tag.
+
+## History
+
+### 2019-05-15. Commit: 263ba5ce3f8d6b41327beb521d4112906841e257
+
+**Detected unstable test**
+
+It was observed that travic_ci builds randomly fails.
+
+Narrowing search it was found that problem arises in `pkg/messaging` tests.
+
+Using this procedure it was found that problem test is `TestClientConnectInitialServers` in `./pkg/messaging/client_test.go`.
+
+Temporary solution: test was moved to `./pkg/messaging/client_test.go` and tagged with: `!no_ci`
+
+**Stable but possibly incorrect tests**
+
+
+1. TestReadWriterConcurrentTCP
+```sh
+$ grep coverage ./logs/internal/*.log
+# ./logs/internal/TestReadWriterConcurrentTCP.log
+# 1:ok    github.com/skycoin/skywire/internal/noise       1.545s  coverage: 0.0% of statements
+# 2:ok    github.com/skycoin/skywire/internal/noise       1.427s  coverage: 0.0% of statements
+# 3:ok    github.com/skycoin/skywire/internal/noise       1.429s  coverage: 0.0% of statements
+# 4:ok    github.com/skycoin/skywire/internal/noise       1.429s  coverage: 0.0% of statements
+# 5:ok    github.com/skycoin/skywire/internal/noise       1.436s  coverage: 0.0% of statements
+```
+
+Note 0.0% coverage

--- a/docs/Tests.Detection-of-unstable-tests.md
+++ b/docs/Tests.Detection-of-unstable-tests.md
@@ -137,3 +137,5 @@ $ grep coverage ./logs/internal/*.log
 ```
 
 Note 0.0% coverage
+
+Test removed.

--- a/pkg/messaging/client_no_ci_test.go
+++ b/pkg/messaging/client_no_ci_test.go
@@ -1,0 +1,60 @@
+// +build !no_ci
+
+package messaging
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/messaging-discovery/client"
+)
+
+func TestClientConnectInitialServers(t *testing.T) {
+	pk, sk := cipher.GenerateKeyPair()
+	discovery := client.NewMock()
+	c := NewClient(&Config{pk, sk, discovery, 1, 100 * time.Millisecond})
+
+	srv, err := newMockServer(discovery)
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	require.NoError(t, c.ConnectToInitialServers(context.TODO(), 1))
+	c.mu.RLock()
+	require.Len(t, c.links, 1)
+	c.mu.RUnlock()
+
+	entry, err := discovery.Entry(context.TODO(), pk)
+	require.NoError(t, err)
+	assert.Len(t, entry.Client.DelegatedServers, 1)
+	assert.Equal(t, srv.config.Public, entry.Client.DelegatedServers[0])
+
+	c.mu.RLock()
+	l := c.links[srv.config.Public]
+	c.mu.RUnlock()
+	require.NotNil(t, l)
+	require.NoError(t, l.link.Close())
+
+	time.Sleep(200 * time.Millisecond)
+
+	c.mu.RLock()
+	require.Len(t, c.links, 1)
+	c.mu.RUnlock()
+
+	require.NoError(t, c.Close())
+
+	time.Sleep(100 * time.Millisecond)
+
+	c.mu.RLock()
+	require.Len(t, c.links, 0)
+	c.mu.RUnlock()
+
+	entry, err = discovery.Entry(context.TODO(), pk)
+	require.NoError(t, err)
+	require.Len(t, entry.Client.DelegatedServers, 0)
+}

--- a/pkg/messaging/client_test.go
+++ b/pkg/messaging/client_test.go
@@ -24,51 +24,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestClientConnectInitialServers(t *testing.T) {
-	pk, sk := cipher.GenerateKeyPair()
-	discovery := client.NewMock()
-	c := NewClient(&Config{pk, sk, discovery, 1, 100 * time.Millisecond})
-
-	srv, err := newMockServer(discovery)
-	require.NoError(t, err)
-
-	time.Sleep(100 * time.Millisecond)
-
-	require.NoError(t, c.ConnectToInitialServers(context.TODO(), 1))
-	c.mu.RLock()
-	require.Len(t, c.links, 1)
-	c.mu.RUnlock()
-
-	entry, err := discovery.Entry(context.TODO(), pk)
-	require.NoError(t, err)
-	assert.Len(t, entry.Client.DelegatedServers, 1)
-	assert.Equal(t, srv.config.Public, entry.Client.DelegatedServers[0])
-
-	c.mu.RLock()
-	l := c.links[srv.config.Public]
-	c.mu.RUnlock()
-	require.NotNil(t, l)
-	require.NoError(t, l.link.Close())
-
-	time.Sleep(200 * time.Millisecond)
-
-	c.mu.RLock()
-	require.Len(t, c.links, 1)
-	c.mu.RUnlock()
-
-	require.NoError(t, c.Close())
-
-	time.Sleep(100 * time.Millisecond)
-
-	c.mu.RLock()
-	require.Len(t, c.links, 0)
-	c.mu.RUnlock()
-
-	entry, err = discovery.Entry(context.TODO(), pk)
-	require.NoError(t, err)
-	require.Len(t, entry.Client.DelegatedServers, 0)
-}
-
 func TestClientDial(t *testing.T) {
 	pk, sk := cipher.GenerateKeyPair()
 	discovery := client.NewMock()


### PR DESCRIPTION
Changes:

1. docs/Tests.Detection-of-unstable-tests.md: Description of unstable
tests detection procedure with results for mainnet branch on 2019-05-15 (commit a70894c8c4223424151cdff7441b1fb2e6bad309)
2. ci_scripts/run-internal-tests.sh, ci_scripts/run-pkg-tests.sh -
scripts created during detection
3. pkg/messaging/client_test.go, pkg/messaging/client_no_ci_test.go -
unstable test TestClientConnectInitialServers tagged with '!no_ci'
4. formatted, linted, checked

Closes: #280 