### PR TITLE
First implementation of atomic noise.ReadWriter.

### DIFF
--- a/internal/noise/noise_test.go
+++ b/internal/noise/noise_test.go
@@ -48,13 +48,13 @@ func TestKKAndSecp256k1(t *testing.T) {
 	require.True(t, nI.HandshakeFinished())
 	require.True(t, nR.HandshakeFinished())
 
-	encrypted := nI.Encrypt([]byte("foo"))
-	decrypted, err := nR.Decrypt(encrypted)
+	encrypted := nI.EncryptUnsafe([]byte("foo"))
+	decrypted, err := nR.DecryptUnsafe(encrypted)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("foo"), decrypted)
 
-	encrypted = nR.Encrypt([]byte("bar"))
-	decrypted, err = nI.Decrypt(encrypted)
+	encrypted = nR.EncryptUnsafe([]byte("bar"))
+	decrypted, err = nI.DecryptUnsafe(encrypted)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("bar"), decrypted)
 
@@ -105,13 +105,13 @@ func TestXKAndSecp256k1(t *testing.T) {
 	require.True(t, nI.HandshakeFinished())
 	require.True(t, nR.HandshakeFinished())
 
-	encrypted := nI.Encrypt([]byte("foo"))
-	decrypted, err := nR.Decrypt(encrypted)
+	encrypted := nI.EncryptUnsafe([]byte("foo"))
+	decrypted, err := nR.DecryptUnsafe(encrypted)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("foo"), decrypted)
 
-	encrypted = nR.Encrypt([]byte("bar"))
-	decrypted, err = nI.Decrypt(encrypted)
+	encrypted = nR.EncryptUnsafe([]byte("bar"))
+	decrypted, err = nI.DecryptUnsafe(encrypted)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("bar"), decrypted)
 

--- a/internal/noise/read_writer.go
+++ b/internal/noise/read_writer.go
@@ -3,6 +3,7 @@ package noise
 import (
 	"errors"
 	"io"
+	"sync"
 	"time"
 
 	"github.com/skycoin/skywire/internal/ioutil"
@@ -13,63 +14,44 @@ import (
 type ReadWriter struct {
 	lrw *ioutil.LenReadWriter
 	ns  *Noise
+
+	rMx sync.Mutex
+	wMx sync.Mutex
 }
 
 // NewReadWriter constructs a new ReadWriter.
 func NewReadWriter(rw io.ReadWriter, ns *Noise) *ReadWriter {
-	return &ReadWriter{ioutil.NewLenReadWriter(rw), ns}
+	return &ReadWriter{
+		lrw: ioutil.NewLenReadWriter(rw),
+		ns:  ns,
+	}
 }
 
-// ReadPacket returns single received len prepended packet.
-func (rw *ReadWriter) ReadPacket() (data []byte, err error) {
-	data, err = rw.lrw.ReadPacket()
+func (rw *ReadWriter) Read(p []byte) (int, error) {
+	rw.rMx.Lock()
+	defer rw.rMx.Unlock()
+
+	ciphertext, err := rw.lrw.ReadPacket()
 	if err != nil {
-		return
+		return 0, err
 	}
-
-	return rw.ns.Decrypt(data)
-}
-
-// ReadPacketUnsafe returns single received len prepended packet using DecryptUnsafe.
-func (rw *ReadWriter) ReadPacketUnsafe() (data []byte, err error) {
-	data, err = rw.lrw.ReadPacket()
+	plaintext, err := rw.ns.DecryptUnsafe(ciphertext)
 	if err != nil {
-		return
+		return 0, err
 	}
-
-	return rw.ns.DecryptUnsafe(data)
-}
-
-func (rw *ReadWriter) Read(p []byte) (n int, err error) {
-	var data []byte
-	data, err = rw.ReadPacket()
-	if err != nil {
-		return
+	if len(plaintext) > len(p) {
+		return 0, io.ErrShortBuffer
 	}
-
-	if len(data) > len(p) {
-		err = io.ErrShortBuffer
-		return
-	}
-
-	return copy(p, data), nil
-}
-
-// WriteUnsafe implements io.Writer using EncryptUnsafe.
-func (rw *ReadWriter) WriteUnsafe(p []byte) (n int, err error) {
-	encrypted := rw.ns.EncryptUnsafe(p)
-	n, err = rw.lrw.Write(encrypted)
-	if n != len(encrypted) {
-		err = io.ErrShortWrite
-		return
-	}
-	return len(p), err
+	return copy(p, plaintext), nil
 }
 
 func (rw *ReadWriter) Write(p []byte) (n int, err error) {
-	encrypted := rw.ns.Encrypt(p)
-	n, err = rw.lrw.Write(encrypted)
-	if n != len(encrypted) {
+	rw.wMx.Lock()
+	defer rw.wMx.Unlock()
+
+	ciphertext := rw.ns.EncryptUnsafe(p)
+	n, err = rw.lrw.Write(ciphertext)
+	if n != len(ciphertext) {
 		err = io.ErrShortWrite
 		return
 	}

--- a/internal/noise/read_writer_test.go
+++ b/internal/noise/read_writer_test.go
@@ -1,6 +1,7 @@
 package noise
 
 import (
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -10,6 +11,95 @@ import (
 
 	"github.com/skycoin/skywire/pkg/cipher"
 )
+
+func TestNewReadWriter(t *testing.T) {
+
+	type Result struct {
+		n   int
+		err error
+		b   []byte
+	}
+
+	t.Run("concurrent", func(t *testing.T) {
+		aPK, aSK := cipher.GenerateKeyPair()
+		bPK, bSK := cipher.GenerateKeyPair()
+
+		aNs, err := KKAndSecp256k1(Config{
+			LocalPK:   aPK,
+			LocalSK:   aSK,
+			RemotePK:  bPK,
+			Initiator: true,
+		})
+		require.NoError(t, err)
+
+		bNs, err := KKAndSecp256k1(Config{
+			LocalPK:   bPK,
+			LocalSK:   bSK,
+			RemotePK:  aPK,
+			Initiator: false,
+		})
+
+		aConn, bConn := net.Pipe()
+		defer func() {
+			_ = aConn.Close() //nolint:errcheck
+			_ = bConn.Close() //nolint:errcheck
+		}()
+
+		aRW := NewReadWriter(aConn, aNs)
+		bRW := NewReadWriter(bConn, bNs)
+
+		hsCh := make(chan error, 2)
+		defer close(hsCh)
+		go func() { hsCh <- aRW.Handshake(time.Second) }()
+		go func() { hsCh <- bRW.Handshake(time.Second) }()
+		require.NoError(t, <-hsCh)
+		require.NoError(t, <-hsCh)
+
+		const groupSize = 10
+		const totalGroups = 5
+		const msgCount = totalGroups * groupSize
+
+		writes := make([][]byte, msgCount)
+
+		wCh := make(chan Result, msgCount)
+		defer close(wCh)
+		rCh := make(chan Result, msgCount)
+		defer close(rCh)
+
+		for i := 0; i < msgCount; i++ {
+			writes[i] = []byte(fmt.Sprintf("this is message: %d", i))
+		}
+
+		for i := 0; i < totalGroups; i++ {
+			go func(i int) {
+				for j := 0; j < groupSize; j++ {
+					go func(i, j int) {
+						b := writes[i*j]
+						n, err := aRW.Write(b)
+						wCh <- Result{n: n, err: err, b: b}
+					}(i, j)
+					go func(i, j int) {
+						buf := make([]byte, 100)
+						n, err := bRW.Read(buf)
+						rCh <- Result{n: n, err: err, b: buf[:n]}
+					}(i, j)
+				}
+			}(i)
+		}
+
+		for i := 0; i < msgCount; i++ {
+			w := <-wCh
+			fmt.Printf("write_result[%d]: b(%s) err(%v)\n", i, string(w.b), w.err)
+			assert.NoError(t, w.err)
+			assert.True(t, w.n > 0)
+
+			r := <-rCh
+			fmt.Printf(" read_result[%d]: b(%s) err(%v)\n", i, string(r.b), r.err)
+			assert.NoError(t, r.err)
+			assert.True(t, r.n > 0)
+		}
+	})
+}
 
 func TestReadWriterKKPattern(t *testing.T) {
 	pkI, skI := cipher.GenerateKeyPair()

--- a/internal/noise/read_writer_test.go
+++ b/internal/noise/read_writer_test.go
@@ -38,6 +38,7 @@ func TestNewReadWriter(t *testing.T) {
 			RemotePK:  aPK,
 			Initiator: false,
 		})
+		require.NoError(t, err)
 
 		aConn, bConn := net.Pipe()
 		defer func() {
@@ -78,11 +79,11 @@ func TestNewReadWriter(t *testing.T) {
 						n, err := aRW.Write(b)
 						wCh <- Result{n: n, err: err, b: b}
 					}(i, j)
-					go func(i, j int) {
+					go func() {
 						buf := make([]byte, 100)
 						n, err := bRW.Read(buf)
 						rCh <- Result{n: n, err: err, b: buf[:n]}
-					}(i, j)
+					}()
 				}
 			}(i)
 		}

--- a/pkg/messaging/channel.go
+++ b/pkg/messaging/channel.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"io"
+	"sync"
 	"time"
 
 	"github.com/skycoin/skywire/internal/noise"
@@ -27,6 +28,8 @@ type channel struct {
 	doneChan  chan struct{}
 
 	noise *noise.Noise
+	rMx   sync.Mutex
+	wMx   sync.Mutex
 }
 
 // Edges returns the public keys of the channel's edge nodes
@@ -90,6 +93,9 @@ func (c *channel) Write(p []byte) (n int, err error) {
 		error
 	})
 	go func() {
+		c.wMx.Lock()
+		defer c.wMx.Unlock()
+
 		data := c.noise.EncryptUnsafe(p)
 		buf := make([]byte, 2)
 		binary.BigEndian.PutUint16(buf, uint16(len(data)))
@@ -147,6 +153,9 @@ func (c *channel) close() {
 }
 
 func (c *channel) readEncrypted(ctx context.Context, p []byte) (n int, err error) {
+	c.rMx.Lock()
+	defer c.rMx.Unlock()
+
 	buf := new(bytes.Buffer)
 	readAtLeast := func(d []byte) (int, error) {
 		for {

--- a/pkg/messaging/channel.go
+++ b/pkg/messaging/channel.go
@@ -90,7 +90,7 @@ func (c *channel) Write(p []byte) (n int, err error) {
 		error
 	})
 	go func() {
-		data := c.noise.Encrypt(p)
+		data := c.noise.EncryptUnsafe(p)
 		buf := make([]byte, 2)
 		binary.BigEndian.PutUint16(buf, uint16(len(data)))
 		n, err := c.link.Send(c.ID, append(buf, data...))
@@ -181,7 +181,7 @@ func (c *channel) readEncrypted(ctx context.Context, p []byte) (n int, err error
 		return 0, err
 	}
 
-	data, err := c.noise.Decrypt(encrypted)
+	data, err := c.noise.DecryptUnsafe(encrypted)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/messaging/channel_test.go
+++ b/pkg/messaging/channel_test.go
@@ -34,14 +34,14 @@ func TestChannelRead(t *testing.T) {
 	require.Equal(t, ErrDeadlineExceeded, err)
 
 	go func() {
-		data := rn.Encrypt([]byte("foo"))
+		data := rn.EncryptUnsafe([]byte("foo"))
 		buf := make([]byte, 2)
 		binary.BigEndian.PutUint16(buf, uint16(len(data)))
 		buf = append(buf, data...)
 		c.readChan <- buf[0:3]
 		c.readChan <- buf[3:]
 
-		data = rn.Encrypt([]byte("foo"))
+		data = rn.EncryptUnsafe([]byte("foo"))
 		buf = make([]byte, 2)
 		binary.BigEndian.PutUint16(buf, uint16(len(data)))
 		buf = append(buf, data...)
@@ -95,7 +95,7 @@ func TestChannelWrite(t *testing.T) {
 	assert.Equal(t, byte(10), buf[3])
 	require.Equal(t, uint16(19), binary.BigEndian.Uint16(buf[4:]))
 
-	data, err := rn.Decrypt(buf[6:])
+	data, err := rn.DecryptUnsafe(buf[6:])
 	require.NoError(t, err)
 	assert.Equal(t, []byte("foo"), data)
 

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -230,7 +230,7 @@ func (r *Router) consumePacket(payload []byte, rule routing.Rule) error {
 		return errors.New("unknown loop")
 	}
 
-	data, err := l.noise.Decrypt(payload)
+	data, err := l.noise.DecryptUnsafe(payload)
 	if err != nil {
 		return fmt.Errorf("noise: %s", err)
 	}
@@ -260,7 +260,7 @@ func (r *Router) forwardAppPacket(appConn *app.Protocol, packet *app.Packet) err
 		return errors.New("unknown transport")
 	}
 
-	p := routing.MakePacket(l.routeID, l.noise.Encrypt(packet.Payload))
+	p := routing.MakePacket(l.routeID, l.noise.EncryptUnsafe(packet.Payload))
 	r.Logger.Infof("Forwarded App packet from LocalPort %d using route ID %d", packet.Addr.Port, l.routeID)
 	_, err = tr.Write(p)
 	return err

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -197,11 +197,11 @@ func TestRouterApp(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint16(19), packet.Size())
 	assert.Equal(t, routing.RouteID(4), packet.RouteID())
-	decrypted, err := ni2.Decrypt(packet.Payload())
+	decrypted, err := ni2.DecryptUnsafe(packet.Payload())
 	require.NoError(t, err)
 	assert.Equal(t, []byte("bar"), decrypted)
 
-	_, err = tr2.Write(routing.MakePacket(routeID, ni2.Encrypt([]byte("foo"))))
+	_, err = tr2.Write(routing.MakePacket(routeID, ni2.EncryptUnsafe([]byte("foo"))))
 	require.NoError(t, err)
 
 	time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
closes #331 

* Removed locks from noise.Noise.
* Added read+decrypt and encrypt+write operation locks to noise.ReadWriter.
* Test noise.ReadWriter concurrently.
* Updated codebase to accomodate changes to noise library.