### PR TITLE
BUG: Ensure modules using internal/httpauth retries with correct nonce after 401. 

### DIFF
--- a/internal/httpauth/client.go
+++ b/internal/httpauth/client.go
@@ -45,7 +45,7 @@ type Client struct {
 	key    cipher.PubKey
 	sec    cipher.SecKey
 	Addr   string // sanitized address of the client, which may differ from addr used in NewClient
-	nonce  uint64
+	nonce  uint64 // has to be handled with the atomic package at all time
 }
 
 // NewClient creates a new client setting a public key to the client to be used for Auth.
@@ -164,7 +164,7 @@ func (c *Client) doRequest(req *http.Request, body []byte) (*http.Response, erro
 }
 
 func (c *Client) getCurrentNonce() Nonce {
-	return Nonce(c.nonce)
+	return Nonce(atomic.LoadUint64(&c.nonce))
 }
 
 func (c *Client) incrementNonce() {

--- a/internal/httpauth/client.go
+++ b/internal/httpauth/client.go
@@ -44,7 +44,7 @@ type Client struct {
 	client http.Client
 	key    cipher.PubKey
 	sec    cipher.SecKey
-	Addr   string // sanitized address of the client, which may differ from addr used in NewClient
+	addr   string // sanitized address of the client, which may differ from addr used in NewClient
 	nonce  uint64 // has to be handled with the atomic package at all time
 }
 
@@ -59,7 +59,7 @@ func NewClient(ctx context.Context, addr string, key cipher.PubKey, sec cipher.S
 		client: http.Client{},
 		key:    key,
 		sec:    sec,
-		Addr:   sanitizedAddr(addr),
+		addr:   sanitizedAddr(addr),
 	}
 
 	// request server for a nonce
@@ -119,7 +119,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 
 // Nonce calls the remote API to retrieve the next expected nonce
 func (c *Client) Nonce(ctx context.Context, key cipher.PubKey) (Nonce, error) {
-	req, err := http.NewRequest(http.MethodGet, c.Addr+"/security/nonces/"+key.Hex(), nil)
+	req, err := http.NewRequest(http.MethodGet, c.addr+"/security/nonces/"+key.Hex(), nil)
 	if err != nil {
 		return 0, err
 	}
@@ -146,6 +146,11 @@ func (c *Client) Nonce(ctx context.Context, key cipher.PubKey) (Nonce, error) {
 // SetNonce sets client current nonce to given nonce
 func (c *Client) SetNonce(n Nonce) {
 	atomic.StoreUint64(&c.nonce, uint64(n))
+}
+
+// Addr returns sanitized address of the client
+func (c *Client) Addr() string {
+	return c.addr
 }
 
 func (c *Client) doRequest(req *http.Request, body []byte) (*http.Response, error) {

--- a/internal/httpauth/client_test.go
+++ b/internal/httpauth/client_test.go
@@ -47,7 +47,8 @@ func TestClient(t *testing.T) {
 	checkResp(t, headers, b, pk, 1)
 }
 
-func TestBadNonce(t *testing.T) {
+// TestClient_BadNonce tests if `Client` retries the request if an invalid nonce is set.
+func TestClient_BadNonce(t *testing.T) {
 	pk, sk := cipher.GenerateKeyPair()
 
 	headerCh := make(chan http.Header, 1)
@@ -71,35 +72,6 @@ func TestBadNonce(t *testing.T) {
 
 	headers := <-headerCh
 	checkResp(t, headers, b, pk, 1)
-}
-
-func TestTooManyRetries(t *testing.T) {
-	pk, sk := cipher.GenerateKeyPair()
-
-	respCh := make(chan string, maxRetries)
-	ts := newBadNonceServer(pk, respCh)
-	defer ts.Close()
-
-	c, err := NewClient(context.TODO(), ts.URL, pk, sk)
-	require.NoError(t, err)
-
-	req, err := http.NewRequest("GET", ts.URL+"/foo", bytes.NewBufferString(payload))
-	require.NoError(t, err)
-	res, err := c.Do(req)
-	require.NoError(t, err)
-
-	b, err := ioutil.ReadAll(res.Body)
-	require.NoError(t, err)
-	res.Body.Close()
-	assert.Equal(t, payload, string(b))
-
-	for i := 0; i < maxRetries-1; i++ {
-		resp := <-respCh
-		assert.Equal(t, errorMessage, resp)
-	}
-
-	resp := <-respCh
-	assert.Equal(t, payload, resp)
 }
 
 func checkResp(t *testing.T, headers http.Header, body []byte, pk cipher.PubKey, nonce int) {
@@ -129,28 +101,6 @@ func newTestServer(pk cipher.PubKey, headerCh chan<- http.Header) *httptest.Serv
 				nonce++
 			}
 			fmt.Fprint(w, respMessage)
-		}
-	}))
-}
-
-func newBadNonceServer(pk cipher.PubKey, respCh chan<- string) *httptest.Server {
-	nonce := 1
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.String() == fmt.Sprintf("/security/nonces/%s", pk) {
-			json.NewEncoder(w).Encode(&NextNonceResponse{pk, Nonce(nonce)}) // nolint: errcheck
-		} else {
-			body, err := ioutil.ReadAll(r.Body)
-			if err != nil {
-				return
-			}
-			defer r.Body.Close()
-			respMessage := string(body)
-			if nonce < maxRetries || r.Header.Get("Sw-Nonce") != strconv.Itoa(nonce) {
-				respMessage = errorMessage
-			}
-			nonce++
-			fmt.Fprint(w, respMessage)
-			respCh <- respMessage
 		}
 	}))
 }

--- a/pkg/transport-discovery/client/client.go
+++ b/pkg/transport-discovery/client/client.go
@@ -53,7 +53,7 @@ func (c *apiClient) Post(ctx context.Context, path string, payload interface{}) 
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", c.client.Addr+path, body)
+	req, err := http.NewRequest("POST", c.client.Addr()+path, body)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func (c *apiClient) Post(ctx context.Context, path string, payload interface{}) 
 
 // Get performs a new GET request.
 func (c *apiClient) Get(ctx context.Context, path string) (*http.Response, error) {
-	req, err := http.NewRequest("GET", c.client.Addr+path, new(bytes.Buffer))
+	req, err := http.NewRequest("GET", c.client.Addr()+path, new(bytes.Buffer))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #345.

In this PR, `internal/httpauth` requests a new nonce and retries HTTP request if a nonce validation error is returned.

The new behavior may be tested running the following commands:
```
go test ./internal/httpauth -run TestClient_BadNonce
```