### PR TITLE
Cleanup.  README.org-files are converted to README.md

### DIFF
--- a/cmd/apps/chat/README.md
+++ b/cmd/apps/chat/README.md
@@ -1,15 +1,18 @@
-* Skywire Chat app
+# Skywire Chat app
 
-Chat implements basic text messaging between skywire nodes. Messaging
-UI is exposed via web interface. Chat only supports one WEB client
-user at a time.
+Chat implements basic text messaging between skywire nodes.
 
-** Local setup
+Messaging UI is exposed via web interface.
+
+Chat only supports one WEB client user at a time.
+
+## Local setup
 
 Create 2 node config files:
 
-~skywire1.json~
-#+BEGIN_SRC js
+`skywire1.json`
+
+```json
   "apps": [
     {
       "app": "chat",
@@ -18,10 +21,11 @@ Create 2 node config files:
       "port": 1
     }
   ]
-#+END_SRC
+```
 
-~skywire2.json~
-#+BEGIN_SRC js
+`skywire2.json`
+
+```json
   "apps": [
     {
       "app": "chat",
@@ -31,14 +35,14 @@ Create 2 node config files:
       "args": ["-addr", ":8001"]
     }
   ]
-#+END_SRC
+```
 
 Compile binaries and start 2 nodes:
 
-#+BEGIN_SRC bash
+```bash
 $ go build -o apps/chat.v1.0 ./cmd/apps/chat
 $ ./skywire-node skywire1.json
 $ ./skywire-node skywire2.json
-#+END_SRC
+```
 
-Chat interface will be available on ports ~8000~ and ~8001~.
+Chat interface will be available on ports `8000` and `8001`.

--- a/cmd/apps/therealproxy-client/README.md
+++ b/cmd/apps/therealproxy-client/README.md
@@ -1,0 +1,11 @@
+# Skywire SOCKS5 proxy client app
+
+`therealproxy-client` app implements client for the SOCKS5 app.
+
+It opens persistent `skywire` connection to the configured remote node
+and local TCP port, all incoming TCP traffics is forwarded to the
+~skywire~ connection.
+
+Any conventional SOCKS5 client should be able to connect to the proxy client.
+
+Please check docs for `therealproxy` app for further instructions.

--- a/cmd/apps/therealproxy-client/README.org
+++ b/cmd/apps/therealproxy-client/README.org
@@ -1,8 +1,0 @@
-* Skywire SOCKS5 proxy client app
-
-~therealproxy-client~ app implements client for the SOCKS5 app. It
-opens persistent ~skywire~ connection to the configured remote node
-and local TCP port, all incoming TCP traffics is forwarded to the
-~skywire~ connection. Any conventional SOCKS5 client should be able to
-connect to the proxy client. Please check docs for ~therealproxy~ app
-for further instructions.

--- a/cmd/apps/therealproxy-client/therealproxy-client.go
+++ b/cmd/apps/therealproxy-client/therealproxy-client.go
@@ -40,10 +40,14 @@ func main() {
 		log.Fatal("Failed to dial to a server: ", err)
 	}
 
+	log.Printf("Connected to %v\n", pk)
+
 	client, err := therealproxy.NewClient(conn)
 	if err != nil {
 		log.Fatal("Failed to create a new client: ", err)
 	}
+
+	log.Printf("Serving  %v\n", addr)
 
 	log.Fatal(client.ListenAndServe(*addr))
 }

--- a/cmd/apps/therealproxy/README.md
+++ b/cmd/apps/therealproxy/README.md
@@ -1,15 +1,20 @@
-* Skywire SOCKS5 proxy app
+# Skywire SOCKS5 proxy app
 
-~therealproxy~ app implements SOCKS5 functionality over skywire
-net. Any conventional SOCKS5 client should be able to connect to the
-proxy client. Currently the server supports authentication with a user and passcode pair that are set in the configuration file. If none are provided, the server does not require authentication. 
+`therealproxy` app implements SOCKS5 functionality over skywire
+net.
+Any conventional SOCKS5 client should be able to connect to the
+proxy client.
+Currently the server supports authentication with a user and passcode pair
+that are set in the configuration file.
+If none are provided, the server does not require authentication.
 
-** Local setup
+## Local setup
 
 Create 2 node config files:
 
-~skywire1.json~
-#+BEGIN_SRC js
+- `skywire1.json`
+
+```json
   "apps": [
     {
       "app": "therealproxy",
@@ -19,10 +24,11 @@ Create 2 node config files:
       "args": ["-passcode", "123456"]
     }
   ]
-#+END_SRC
+```
 
-~skywire2.json~
-#+BEGIN_SRC js
+- `skywire2.json`
+
+```json
   "apps": [
     {
       "app": "therealproxy-client",
@@ -32,19 +38,19 @@ Create 2 node config files:
       "args": ["-srv", "024ec47420176680816e0406250e7156465e4531f5b26057c9f6297bb0303558c7"]
     }
   ]
-#+END_SRC
+```
 
 Compile binaries and start 2 nodes:
 
-#+BEGIN_SRC bash
+```sh
 $ go build -o apps/therealproxy.v1.0 ./cmd/apps/therealproxy
 $ go build -o apps/therealproxy-client.v1.0 ./cmd/apps/therealproxy-client
 $ ./skywire-node skywire1.json
 $ ./skywire-node skywire2.json
-#+END_SRC
+```
 
-You should be able to connect to a secondary node via ~curl~:
+You should be able to connect to a secondary node via `curl`:
 
-#+BEGIN_SRC bash
+```sh
 $ curl -v -x socks5://123456:@localhost:1080 https://api.ipify.org
-#+END_SRC
+```

--- a/cmd/apps/therealssh-client/README.md
+++ b/cmd/apps/therealssh-client/README.md
@@ -1,0 +1,8 @@
+# Skywire SSH client app
+
+`therealssh-client` app implements client for the SSH app. 
+
+It starts RCP interface for `therealssh-cli` and handles incoming requests to
+the remote node via `skywire` connection.
+
+Please check docs for `therealssh` app for further instructions.

--- a/cmd/apps/therealssh-client/README.org
+++ b/cmd/apps/therealssh-client/README.org
@@ -1,6 +1,0 @@
-* Skywire SSH client app
-
-~therealssh-client~ app implements client for the SSH app. It starts
-RCP interface for ~therealssh-cli~ and handles incoming requests to
-the remote node via ~skywire~ connection. Please check docs for
-~therealssh~ app for further instructions.

--- a/cmd/apps/therealssh/README.md
+++ b/cmd/apps/therealssh/README.md
@@ -1,18 +1,25 @@
-* Skywire SSH app
+# Skywire SSH app
 
-~therealssh~ app implements SSH functionality over skywire
-net. ~therealssh-cli~ is used to initiate communication via client RPC
-exposed by ~therealssh~ app. ~therealssh~ app implements common SSH
-operations: starting remote shell and executing commands
-remotely. PubKey whitelisting is performed by adding public key to the
-authentication file (~$HOME/.therealssh/authorized_keys~ by default).
+`therealssh` app implements SSH functionality over skywirenet.
+
+`therealssh-cli` is used to initiate communication via client RPC
+exposed by `therealssh` app. 
+
+`therealssh` app implements common SSH operations:
+
+- starting remote shell
+- and executing commands remotely
+
+PubKey whitelisting is performed by adding public key to the
+authentication file (`$HOME/.therealssh/authorized_keys` by default).
 
 ** Local setup
 
 Create 2 node config files:
 
-~skywire1.json~
-#+BEGIN_SRC js
+`skywire1.json`
+
+```json
   "apps": [
     {
       "app": "therealssh",
@@ -21,10 +28,11 @@ Create 2 node config files:
       "port": 2
     }
   ]
-#+END_SRC
+```
 
-~skywire2.json~
-#+BEGIN_SRC js
+`skywire2.json`
+
+```json
   "apps": [
     {
       "app": "therealssh-client",
@@ -33,30 +41,30 @@ Create 2 node config files:
       "port": 22
     }
   ]
-#+END_SRC
+```
 
 Compile binaries and start 2 nodes:
 
-#+BEGIN_SRC bash
+```bash
 $ go build -o apps/therealssh.v1.0 ./cmd/apps/therealssh
 $ go build -o apps/therealssh-client.v1.0 ./cmd/apps/therealssh-client
 $ go build ./cmd/therealssh-cli
 $ ./skywire-node skywire1.json
 $ ./skywire-node skywire2.json
-#+END_SRC
+```
 
 Add public key of the second node to the auth file:
 
-#+BEGIN_SRC bash
-$ mkdir ~/.therealssh
-$ echo "0348c941c5015a05c455ff238af2e57fb8f914c399aab604e9abb5b32b91a4c1fe" > ~/.therealssh/authorized_keys
-#+END_SRC
+```bash
+$ mkdir `/.therealssh
+$ echo "0348c941c5015a05c455ff238af2e57fb8f914c399aab604e9abb5b32b91a4c1fe" > `/.therealssh/authorized_keys
+```
 
 Connect to the first node using CLI:
 
-#+BEGIN_SRC bash
+```bash
 $ ./therealssh-cli 024ec47420176680816e0406250e7156465e4531f5b26057c9f6297bb0303558c7
-#+END_SRC
+```
 
-This should get you to the local folder of the ~therealssh~ app, which
+This should get you to the $HOME folder of the user(you in this case), which
 will indicate that you are seeing remote PTY session.

--- a/cmd/therealssh-cli/README.md
+++ b/cmd/therealssh-cli/README.md
@@ -1,0 +1,6 @@
+# CLI for SSH app
+
+`therealssh-cli` implements PTY related operations for SSH app.
+
+It connects to SSH client's RPC server, configures terminal for raw pty
+data and handles pty data exchange.

--- a/cmd/therealssh-cli/README.org
+++ b/cmd/therealssh-cli/README.org
@@ -1,5 +1,0 @@
-* CLI for SSH app
-
-~therealssh-cli~ implements PTY related operations for SSH app. It
-connects to SSH client's RPC server, configures terminal for raw pty
-data and handles pty data exchange.


### PR DESCRIPTION
Most of conversions was done almost mechanically.

With only one exclusion: `./cmd/apps/therealssh/README.md` 

In this file last sentence ```This should get you to the ...` was corrected according to actual behaviour.

Closes: #357 
