### PR TITLE
Cleanup: Eliminate or justify Manager.Observe

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -78,9 +78,10 @@ func New(config *Config) *Router {
 
 // Serve starts transport listening loop.
 func (r *Router) Serve(ctx context.Context) error {
-	acceptCh, dialCh := r.tm.Observe()
+	// acceptCh, dialCh := r.tm.Observe()
+
 	go func() {
-		for tr := range acceptCh {
+		for tr := range r.tm.AcceptedTrChan {
 			go func(t transport.Transport) {
 				for {
 					var err error
@@ -102,7 +103,7 @@ func (r *Router) Serve(ctx context.Context) error {
 	}()
 
 	go func() {
-		for tr := range dialCh {
+		for tr := range r.tm.DialedTrChan {
 			if r.isSetupTransport(tr) {
 				continue
 			}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -78,8 +78,6 @@ func New(config *Config) *Router {
 
 // Serve starts transport listening loop.
 func (r *Router) Serve(ctx context.Context) error {
-	// acceptCh, dialCh := r.tm.Observe()
-
 	go func() {
 		for tr := range r.tm.AcceptedTrChan {
 			go func(t transport.Transport) {

--- a/pkg/setup/node.go
+++ b/pkg/setup/node.go
@@ -90,9 +90,8 @@ func (sn *Node) Serve(ctx context.Context) error {
 		sn.Logger.Info("Connected to messaging servers")
 	}
 
-	acceptCh, dialCh := sn.tm.Observe()
 	go func() {
-		for tr := range acceptCh {
+		for tr := range sn.tm.AcceptedTrChan {
 			go func(t transport.Transport) {
 				for {
 					if err := sn.serveTransport(t); err != nil {
@@ -105,7 +104,7 @@ func (sn *Node) Serve(ctx context.Context) error {
 	}()
 
 	go func() {
-		for range dialCh {
+		for range sn.tm.DialedTrChan {
 		}
 	}()
 

--- a/pkg/setup/node_test.go
+++ b/pkg/setup/node_test.go
@@ -273,15 +273,14 @@ func newMockNode(tm *transport.Manager) *mockNode {
 }
 
 func (n *mockNode) serve() error {
-	acceptCh, dialCh := n.tm.Observe()
 	go func() {
-		for tr := range dialCh {
+		for tr := range n.tm.DialedTrChan {
 			go func(t transport.Transport) { n.serveTransport(t) }(tr) // nolint: errcheck
 		}
 	}()
 
 	go func() {
-		for tr := range acceptCh {
+		for tr := range n.tm.AcceptedTrChan {
 			go func(t transport.Transport) { n.serveTransport(t) }(tr) // nolint: errcheck
 		}
 	}()

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -68,22 +68,6 @@ func NewManager(config *ManagerConfig, factories ...Factory) (*Manager, error) {
 // Observe returns channel for notifications about new Transport
 // registration. Only single observer is supported.
 func (tm *Manager) Observe() (accept <-chan *ManagedTransport, dial <-chan *ManagedTransport) {
-	// dialCh := make(chan *ManagedTransport)
-	// acceptCh := make(chan *ManagedTransport)
-	// go func() {
-	// 	for {
-	// 		select {
-	// 		case <-tm.doneChan:
-	// 			// close(dialCh)
-	// 			// close(acceptCh)
-	// 			return
-	// 		case tr := <-tm.acceptedTrChan:
-	// 			acceptCh <- tr
-	// 		case tr := <-tm.dialedTrChan:
-	// 			dialCh <- tr
-	// 		}
-	// 	}
-	// }()
 	return tm.AcceptedTrChan, tm.DialedTrChan
 }
 

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -33,8 +33,8 @@ type Manager struct {
 	entries    []*Entry
 
 	doneChan       chan struct{}
-	acceptedTrChan chan *ManagedTransport
-	dialedTrChan   chan *ManagedTransport
+	AcceptedTrChan chan *ManagedTransport
+	DialedTrChan   chan *ManagedTransport
 	mu             sync.RWMutex
 }
 
@@ -59,8 +59,8 @@ func NewManager(config *ManagerConfig, factories ...Factory) (*Manager, error) {
 		factories:      fMap,
 		transports:     make(map[uuid.UUID]*ManagedTransport),
 		entries:        mEntries,
-		acceptedTrChan: make(chan *ManagedTransport, 10),
-		dialedTrChan:   make(chan *ManagedTransport, 10),
+		AcceptedTrChan: make(chan *ManagedTransport, 10),
+		DialedTrChan:   make(chan *ManagedTransport, 10),
 		doneChan:       make(chan struct{}),
 	}, nil
 }
@@ -68,23 +68,23 @@ func NewManager(config *ManagerConfig, factories ...Factory) (*Manager, error) {
 // Observe returns channel for notifications about new Transport
 // registration. Only single observer is supported.
 func (tm *Manager) Observe() (accept <-chan *ManagedTransport, dial <-chan *ManagedTransport) {
-	dialCh := make(chan *ManagedTransport)
-	acceptCh := make(chan *ManagedTransport)
-	go func() {
-		for {
-			select {
-			case <-tm.doneChan:
-				// close(dialCh)
-				// close(acceptCh)
-				return
-			case tr := <-tm.acceptedTrChan:
-				acceptCh <- tr
-			case tr := <-tm.dialedTrChan:
-				dialCh <- tr
-			}
-		}
-	}()
-	return acceptCh, dialCh
+	// dialCh := make(chan *ManagedTransport)
+	// acceptCh := make(chan *ManagedTransport)
+	// go func() {
+	// 	for {
+	// 		select {
+	// 		case <-tm.doneChan:
+	// 			// close(dialCh)
+	// 			// close(acceptCh)
+	// 			return
+	// 		case tr := <-tm.acceptedTrChan:
+	// 			acceptCh <- tr
+	// 		case tr := <-tm.dialedTrChan:
+	// 			dialCh <- tr
+	// 		}
+	// 	}
+	// }()
+	return tm.AcceptedTrChan, tm.DialedTrChan
 }
 
 // Factories returns all the factory types contained within the TransportManager.
@@ -317,7 +317,7 @@ func (tm *Manager) createTransport(ctx context.Context, remote cipher.PubKey, tp
 	tm.transports[entry.ID] = managedTr
 	select {
 	case <-tm.doneChan:
-	case tm.dialedTrChan <- managedTr:
+	case tm.DialedTrChan <- managedTr:
 	default:
 	}
 	tm.mu.Unlock()
@@ -390,7 +390,7 @@ func (tm *Manager) acceptTransport(ctx context.Context, factory Factory) (*Manag
 	tm.transports[entry.ID] = managedTr
 	select {
 	case <-tm.doneChan:
-	case tm.acceptedTrChan <- managedTr:
+	case tm.AcceptedTrChan <- managedTr:
 	default:
 	}
 	tm.mu.Unlock()

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -74,8 +74,8 @@ func (tm *Manager) Observe() (accept <-chan *ManagedTransport, dial <-chan *Mana
 		for {
 			select {
 			case <-tm.doneChan:
-				close(dialCh)
-				close(acceptCh)
+				// close(dialCh)
+				// close(acceptCh)
 				return
 			case tr := <-tm.acceptedTrChan:
 				acceptCh <- tr


### PR DESCRIPTION
1. `Manager.Observe` eliminated
2. All tests passed in skywire and skywire-services

Closes: #365 
Partially relates to: #354 
