### PR TITLE
Cleanup. Channel/channel renamings

### DIFF
--- a/internal/therealssh/chan_list.go
+++ b/internal/therealssh/chan_list.go
@@ -5,14 +5,14 @@ import "sync"
 type chanList struct {
 	sync.Mutex
 
-	chans []*SshChannel
+	chans []*SSHChannel
 }
 
 func newChanList() *chanList {
-	return &chanList{chans: []*SshChannel{}}
+	return &chanList{chans: []*SSHChannel{}}
 }
 
-func (c *chanList) add(sshCh *SshChannel) uint32 {
+func (c *chanList) add(sshCh *SSHChannel) uint32 {
 	c.Lock()
 	defer c.Unlock()
 
@@ -27,7 +27,7 @@ func (c *chanList) add(sshCh *SshChannel) uint32 {
 	return uint32(len(c.chans) - 1)
 }
 
-func (c *chanList) getChannel(id uint32) *SshChannel {
+func (c *chanList) getChannel(id uint32) *SSHChannel {
 	c.Lock()
 	defer c.Unlock()
 
@@ -38,10 +38,10 @@ func (c *chanList) getChannel(id uint32) *SshChannel {
 	return nil
 }
 
-func (c *chanList) dropAll() []*SshChannel {
+func (c *chanList) dropAll() []*SSHChannel {
 	c.Lock()
 	defer c.Unlock()
-	var r []*SshChannel
+	var r []*SSHChannel
 
 	for _, ch := range c.chans {
 		if ch == nil {

--- a/internal/therealssh/chan_list.go
+++ b/internal/therealssh/chan_list.go
@@ -5,29 +5,29 @@ import "sync"
 type chanList struct {
 	sync.Mutex
 
-	chans []*Channel
+	chans []*SshChannel
 }
 
 func newChanList() *chanList {
-	return &chanList{chans: []*Channel{}}
+	return &chanList{chans: []*SshChannel{}}
 }
 
-func (c *chanList) add(channel *Channel) uint32 {
+func (c *chanList) add(sshCh *SshChannel) uint32 {
 	c.Lock()
 	defer c.Unlock()
 
 	for i := range c.chans {
 		if c.chans[i] == nil {
-			c.chans[i] = channel
+			c.chans[i] = sshCh
 			return uint32(i)
 		}
 	}
 
-	c.chans = append(c.chans, channel)
+	c.chans = append(c.chans, sshCh)
 	return uint32(len(c.chans) - 1)
 }
 
-func (c *chanList) getChannel(id uint32) *Channel {
+func (c *chanList) getChannel(id uint32) *SshChannel {
 	c.Lock()
 	defer c.Unlock()
 
@@ -38,10 +38,10 @@ func (c *chanList) getChannel(id uint32) *Channel {
 	return nil
 }
 
-func (c *chanList) dropAll() []*Channel {
+func (c *chanList) dropAll() []*SshChannel {
 	c.Lock()
 	defer c.Unlock()
-	var r []*Channel
+	var r []*SshChannel
 
 	for _, ch := range c.chans {
 		if ch == nil {

--- a/internal/therealssh/client.go
+++ b/internal/therealssh/client.go
@@ -46,7 +46,7 @@ func NewClient(rpcAddr string, d Dialer) (net.Listener, *Client, error) {
 }
 
 // OpenChannel requests new Channel on the remote Server.
-func (c *Client) OpenChannel(remotePK cipher.PubKey) (localID uint32, sshCh *SshChannel, cErr error) {
+func (c *Client) OpenChannel(remotePK cipher.PubKey) (localID uint32, sshCh *SSHChannel, cErr error) {
 	conn, err := c.dialer.Dial(&app.Addr{PubKey: remotePK, Port: Port})
 	if err != nil {
 		cErr = fmt.Errorf("dial failed: %s", err)
@@ -80,7 +80,7 @@ func (c *Client) OpenChannel(remotePK cipher.PubKey) (localID uint32, sshCh *Ssh
 	return localID, sshCh, cErr
 }
 
-func (c *Client) resolveChannel(remotePK cipher.PubKey, localID uint32) (*SshChannel, error) {
+func (c *Client) resolveChannel(remotePK cipher.PubKey, localID uint32) (*SSHChannel, error) {
 	sshCh := c.chans.getChannel(localID)
 	if sshCh == nil {
 		return nil, errors.New("channel is not opened")

--- a/internal/therealssh/client_test.go
+++ b/internal/therealssh/client_test.go
@@ -19,7 +19,7 @@ func TestClientOpenChannel(t *testing.T) {
 	c := &Client{dialer, newChanList()}
 
 	type data struct {
-		ch  *Channel
+		ch  *SshChannel
 		err error
 	}
 	resCh := make(chan data)

--- a/internal/therealssh/client_test.go
+++ b/internal/therealssh/client_test.go
@@ -19,7 +19,7 @@ func TestClientOpenChannel(t *testing.T) {
 	c := &Client{dialer, newChanList()}
 
 	type data struct {
-		ch  *SshChannel
+		ch  *SSHChannel
 		err error
 	}
 	resCh := make(chan data)

--- a/pkg/messaging/chan_list.go
+++ b/pkg/messaging/chan_list.go
@@ -5,20 +5,20 @@ import "sync"
 type chanList struct {
 	sync.Mutex
 
-	chans map[byte]*channel
+	chans map[byte]*msgChannel
 }
 
 func newChanList() *chanList {
-	return &chanList{chans: map[byte]*channel{}}
+	return &chanList{chans: map[byte]*msgChannel{}}
 }
 
-func (c *chanList) add(channel *channel) byte {
+func (c *chanList) add(mCh *msgChannel) byte {
 	c.Lock()
 	defer c.Unlock()
 
 	for i := byte(0); i < 255; i++ {
 		if c.chans[i] == nil {
-			c.chans[i] = channel
+			c.chans[i] = mCh
 			return i
 		}
 	}
@@ -26,7 +26,7 @@ func (c *chanList) add(channel *channel) byte {
 	panic("no free channels")
 }
 
-func (c *chanList) get(id byte) *channel {
+func (c *chanList) get(id byte) *msgChannel {
 	c.Lock()
 	ch := c.chans[id]
 	c.Unlock()
@@ -40,10 +40,10 @@ func (c *chanList) remove(id byte) {
 	c.Unlock()
 }
 
-func (c *chanList) dropAll() []*channel {
+func (c *chanList) dropAll() []*msgChannel {
 	c.Lock()
 	defer c.Unlock()
-	var r []*channel
+	var r []*msgChannel
 
 	for _, ch := range c.chans {
 		if ch == nil {

--- a/pkg/messaging/channel_test.go
+++ b/pkg/messaging/channel_test.go
@@ -131,26 +131,26 @@ func TestChannelClose(t *testing.T) {
 	assert.Equal(t, byte(10), buf[3])
 }
 
-func handshakeChannel(t *testing.T, c *channel, pk cipher.PubKey, sk cipher.SecKey) *noise.Noise {
+func handshakeChannel(t *testing.T, mCh *msgChannel, pk cipher.PubKey, sk cipher.SecKey) *noise.Noise {
 	t.Helper()
 
 	noiseConf := noise.Config{
 		LocalSK:   sk,
 		LocalPK:   pk,
-		RemotePK:  c.link.Local(),
+		RemotePK:  mCh.link.Local(),
 		Initiator: false,
 	}
 
 	n, err := noise.KKAndSecp256k1(noiseConf)
 	require.NoError(t, err)
 
-	msg, err := c.noise.HandshakeMessage()
+	msg, err := mCh.noise.HandshakeMessage()
 	require.NoError(t, err)
 
 	require.NoError(t, n.ProcessMessage(msg))
 	msg, err = n.HandshakeMessage()
 	require.NoError(t, err)
 
-	require.NoError(t, c.noise.ProcessMessage(msg))
+	require.NoError(t, mCh.noise.ProcessMessage(msg))
 	return n
 }

--- a/pkg/messaging/client.go
+++ b/pkg/messaging/client.go
@@ -64,7 +64,7 @@ type Client struct {
 	links map[cipher.PubKey]*clientLink
 	mu    sync.RWMutex
 
-	newChan  chan *channel
+	newChan  chan *msgChannel
 	doneChan chan struct{}
 }
 
@@ -78,7 +78,7 @@ func NewClient(conf *Config) *Client {
 		retries:    conf.Retries,
 		retryDelay: conf.RetryDelay,
 		links:      make(map[cipher.PubKey]*clientLink),
-		newChan:    make(chan *channel),
+		newChan:    make(chan *msgChannel),
 		doneChan:   make(chan struct{}),
 	}
 	config := &LinkConfig{


### PR DESCRIPTION
# Problem

There are types: `messaging.channel` and `therealssh.Channel`
   
Which are typically used as `channel *channel`, `channel *Channel`, `c
channel`, `c *Channel`
   
`messaging.channel` implements `transport.Transport` 
`the

This makes search in code ambiguous.

# Renamings
   
This commit contains only renamings like:
   
- `channel *channel` -> `mCh *msgChannel`
- `channel *Channel` -> `sshCh *sshChannel`

This makes search unambiguous and code more clear.

Code linted, tested both in skywire and skywire-services
