### PR TITLE
Further improvements in ManagedTransport concurrency

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -85,6 +85,8 @@ func (r *Router) Serve(ctx context.Context) error {
 			isAccepted, isSetup := tp.Accepted, r.IsSetupTransport(tp)
 			r.mu.Unlock()
 
+			r.Logger.Infof("New transport: isAccepted: %v, isSetup: %v", isAccepted, isSetup)
+
 			var serve func(io.ReadWriter) error
 			switch {
 			case isAccepted && isSetup:

--- a/pkg/transport/discovery_test.go
+++ b/pkg/transport/discovery_test.go
@@ -1,19 +1,20 @@
-package transport
+package transport_test
 
 import (
 	"context"
 	"fmt"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport"
 )
 
 func ExampleNewDiscoveryMock() {
-	dc := NewDiscoveryMock()
+	dc := transport.NewDiscoveryMock()
 	pk1, _ := cipher.GenerateKeyPair()
 	pk2, _ := cipher.GenerateKeyPair()
-	entry := &Entry{Type: "mock", EdgeKeys: SortPubKeys(pk1, pk2)}
+	entry := &transport.Entry{Type: "mock", EdgeKeys: transport.SortPubKeys(pk1, pk2)}
 
-	sEntry := &SignedEntry{Entry: entry}
+	sEntry := &transport.SignedEntry{Entry: entry}
 
 	if err := dc.RegisterTransports(context.TODO(), sEntry); err == nil {
 		fmt.Println("RegisterTransport success")
@@ -33,7 +34,7 @@ func ExampleNewDiscoveryMock() {
 		fmt.Printf("entriesWS[0].Entry.Edges()[0] == entry.Edges()[0] is %v\n", entriesWS[0].Entry.Edges()[0] == entry.Edges()[0])
 	}
 
-	if _, err := dc.UpdateStatuses(context.TODO(), &Status{}); err == nil {
+	if _, err := dc.UpdateStatuses(context.TODO(), &transport.Status{}); err == nil {
 		fmt.Println("UpdateStatuses success")
 	} else {
 		fmt.Println(err.Error())

--- a/pkg/transport/entry_test.go
+++ b/pkg/transport/entry_test.go
@@ -1,4 +1,4 @@
-package transport
+package transport_test
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport"
 )
 
 // ExampleNewEntry shows that with different order of edges:
@@ -15,8 +16,8 @@ func ExampleNewEntry() {
 	pkA, _ := cipher.GenerateKeyPair()
 	pkB, _ := cipher.GenerateKeyPair()
 
-	entryAB := NewEntry(pkA, pkB, "", true)
-	entryBA := NewEntry(pkB, pkA, "", true)
+	entryAB := transport.NewEntry(pkA, pkB, "", true)
+	entryBA := transport.NewEntry(pkB, pkA, "", true)
 
 	if entryAB.ID == entryBA.ID {
 		fmt.Println("entryAB.ID == entryBA.ID")
@@ -32,14 +33,14 @@ func ExampleEntry_Edges() {
 	pkA, _ := cipher.GenerateKeyPair()
 	pkB, _ := cipher.GenerateKeyPair()
 
-	entryAB := Entry{
+	entryAB := transport.Entry{
 		ID:       uuid.UUID{},
 		EdgeKeys: [2]cipher.PubKey{pkA, pkB},
 		Type:     "",
 		Public:   true,
 	}
 
-	entryBA := Entry{
+	entryBA := transport.Entry{
 		ID:       uuid.UUID{},
 		EdgeKeys: [2]cipher.PubKey{pkB, pkA},
 		Type:     "",
@@ -62,7 +63,7 @@ func ExampleEntry_SetEdges() {
 	pkA, _ := cipher.GenerateKeyPair()
 	pkB, _ := cipher.GenerateKeyPair()
 
-	entryAB, entryBA := Entry{}, Entry{}
+	entryAB, entryBA := transport.Entry{}, transport.Entry{}
 
 	entryAB.SetEdges([2]cipher.PubKey{pkA, pkB})
 	entryBA.SetEdges([2]cipher.PubKey{pkA, pkB})
@@ -85,8 +86,8 @@ func ExampleSignedEntry_Sign() {
 	pkA, skA := cipher.GenerateKeyPair()
 	pkB, skB := cipher.GenerateKeyPair()
 
-	entry := NewEntry(pkA, pkB, "mock", true)
-	sEntry := &SignedEntry{Entry: entry}
+	entry := transport.NewEntry(pkA, pkB, "mock", true)
+	sEntry := &transport.SignedEntry{Entry: entry}
 
 	if sEntry.Signatures[0].Null() && sEntry.Signatures[1].Null() {
 		fmt.Println("No signatures set")
@@ -119,8 +120,8 @@ func ExampleSignedEntry_Signature() {
 	pkA, skA := cipher.GenerateKeyPair()
 	pkB, skB := cipher.GenerateKeyPair()
 
-	entry := NewEntry(pkA, pkB, "mock", true)
-	sEntry := &SignedEntry{Entry: entry}
+	entry := transport.NewEntry(pkA, pkB, "mock", true)
+	sEntry := &transport.SignedEntry{Entry: entry}
 	if ok := sEntry.Sign(pkA, skA); !ok {
 		fmt.Println("Error signing sEntry with (pkA,skA)")
 	}

--- a/pkg/transport/handshake_test.go
+++ b/pkg/transport/handshake_test.go
@@ -199,30 +199,6 @@ func TestSettlementHandshake(t *testing.T) {
 
 }
 
-/*
-func TestSettlementHandshakeInvalidSig(t *testing.T) {
-	mockEnv := newHsMockEnv()
-
-	require.NoError(t, mockEnv.err1)
-	require.NoError(t, mockEnv.err2)
-
-	go settlementInitiatorHandshake(true)(mockEnv.m2, mockEnv.tr1) // nolint: errcheck
-	_, err := settlementResponderHandshake(mockEnv.m2, mockEnv.tr2)
-	require.Error(t, err)
-	assert.Equal(t, "Recovered pubkey does not match pubkey", err.Error())
-
-	in, out := net.Pipe()
-	tr1 := NewMockTransport(in, mockEnv.pk1, mockEnv.pk2)
-	tr2 := NewMockTransport(out, mockEnv.pk2, mockEnv.pk1)
-
-	go settlementResponderHandshake(mockEnv.m1, tr2) // nolint: errcheck
-	_, err = settlementInitiatorHandshake(true)(mockEnv.m1, tr1)
-	require.Error(t, err)
-	assert.Equal(t, "Recovered pubkey does not match pubkey", err.Error())
-
-}
-*/
-
 func TestSettlementHandshakePrivate(t *testing.T) {
 	mockEnv := newHsMockEnv()
 

--- a/pkg/transport/log_test.go
+++ b/pkg/transport/log_test.go
@@ -1,4 +1,4 @@
-package transport
+package transport_test
 
 import (
 	"io/ioutil"
@@ -7,17 +7,18 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func testTransportLogStore(t *testing.T, logStore LogStore) {
+func testTransportLogStore(t *testing.T, logStore transport.LogStore) {
 	t.Helper()
 
 	id1 := uuid.New()
-	entry1 := &LogEntry{big.NewInt(100), big.NewInt(200)}
+	entry1 := &transport.LogEntry{big.NewInt(100), big.NewInt(200)}
 	id2 := uuid.New()
-	entry2 := &LogEntry{big.NewInt(300), big.NewInt(400)}
+	entry2 := &transport.LogEntry{big.NewInt(300), big.NewInt(400)}
 
 	require.NoError(t, logStore.Record(id1, entry1))
 	require.NoError(t, logStore.Record(id2, entry2))
@@ -29,7 +30,7 @@ func testTransportLogStore(t *testing.T, logStore LogStore) {
 }
 
 func TestInMemoryTransportLogStore(t *testing.T) {
-	testTransportLogStore(t, InMemoryTransportLogStore())
+	testTransportLogStore(t, transport.InMemoryTransportLogStore())
 }
 
 func TestFileTransportLogStore(t *testing.T) {
@@ -37,7 +38,7 @@ func TestFileTransportLogStore(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	ls, err := FileTransportLogStore(dir)
+	ls, err := transport.FileTransportLogStore(dir)
 	require.NoError(t, err)
 	testTransportLogStore(t, ls)
 }

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -69,6 +69,8 @@ func (tr *ManagedTransport) Write(p []byte) (n int, err error) {
 	return
 }
 
+// killWorker sends signal to Manager.manageTransport goroutine to exit
+// it's safe to call it multiple times
 func (tr *ManagedTransport) killWorker() {
 	select {
 	case <-tr.doneChan:

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -289,6 +289,10 @@ func (tm *Manager) Close() error {
 
 func (tm *Manager) dialTransport(ctx context.Context, factory Factory, remote cipher.PubKey, public bool) (Transport, *Entry, error) {
 
+	if tm.isClosing() {
+		return nil, nil, errors.New("transport.Manager is closing. Skipping dialling transport")
+	}
+
 	tr, err := factory.Dial(ctx, remote)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -205,7 +205,7 @@ func (tm *Manager) Serve(ctx context.Context) error {
 // MakeTransportID generates uuid.UUID from pair of keys + type + public
 // Generated uuid is:
 // - always the same for a given pair
-// - GenTransportUUID(keyA,keyB) == GenTransportUUID(keyB, keyA)
+// - MakeTransportUUID(keyA,keyB) == MakeTransportUUID(keyB, keyA)
 func MakeTransportID(keyA, keyB cipher.PubKey, tpType string, public bool) uuid.UUID {
 	keys := SortPubKeys(keyA, keyB)
 	if public {

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -245,8 +245,6 @@ func (tm *Manager) DeleteTransport(id uuid.UUID) error {
 	tr := tm.transports[id]
 	delete(tm.transports, id)
 	tm.mu.Unlock()
-	mgrQty := atomic.AddInt32(&tm.mgrQty, -1)
-	tm.Logger.Infof("Manager.DeleteTransport id: %v, mgrQty = %v", id, mgrQty)
 
 	tr.Close()
 

--- a/pkg/transport/tcp_transport_test.go
+++ b/pkg/transport/tcp_transport_test.go
@@ -1,4 +1,4 @@
-package transport
+package transport_test
 
 import (
 	"context"
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport"
 )
 
 func TestTCPFactory(t *testing.T) {
@@ -28,10 +29,10 @@ func TestTCPFactory(t *testing.T) {
 	l2, err := net.ListenTCP("tcp", addr2)
 	require.NoError(t, err)
 
-	pkt1 := InMemoryPubKeyTable(map[cipher.PubKey]*net.TCPAddr{pk2: addr2})
-	pkt2 := InMemoryPubKeyTable(map[cipher.PubKey]*net.TCPAddr{pk1: addr1})
+	pkt1 := transport.InMemoryPubKeyTable(map[cipher.PubKey]*net.TCPAddr{pk2: addr2})
+	pkt2 := transport.InMemoryPubKeyTable(map[cipher.PubKey]*net.TCPAddr{pk1: addr1})
 
-	f1 := NewTCPFactory(pk1, pkt1, l1)
+	f1 := transport.NewTCPFactory(pk1, pkt1, l1)
 	errCh := make(chan error)
 	go func() {
 		tr, err := f1.Accept(context.TODO())
@@ -48,7 +49,7 @@ func TestTCPFactory(t *testing.T) {
 		errCh <- nil
 	}()
 
-	f2 := NewTCPFactory(pk2, pkt2, l2)
+	f2 := transport.NewTCPFactory(pk2, pkt2, l2)
 	assert.Equal(t, "tcp", f2.Type())
 	assert.Equal(t, pk2, f2.Local())
 
@@ -79,7 +80,7 @@ func TestFilePKTable(t *testing.T) {
 	_, err = tmpfile.Write([]byte(fmt.Sprintf("%s\t%s\n", pk, addr)))
 	require.NoError(t, err)
 
-	pkt, err := FilePubKeyTable(tmpfile.Name())
+	pkt, err := transport.FilePubKeyTable(tmpfile.Name())
 	require.NoError(t, err)
 
 	raddr := pkt.RemoteAddr(pk)


### PR DESCRIPTION
There are three changes in `Manager`-`ManagedTransport`:

1. Eliminated subtle bug with `manageTransport` and
`manageTransportLogs`
both trying to select from `ManagedTransport.doneChan`. `manageTransportLogs` was eliminated in the process
2. Eliminated subtle bug with only one redial on errors in
`Manager.manageTransport`
3. All blackbox tests in `transport` are now in separate package `transport_test`
4. Implemented `ManagedTransport.killWorker` method, multiple transport creation problem solved


Passes `make test` and integration tests

**UPDATE**

Problem with hanging on first message is solved.


Closes:
#364 