### PR TITLE
Bug: double definition of TestMain in dmsg

### DIFF
--- a/pkg/dmsg/client_test.go
+++ b/pkg/dmsg/client_test.go
@@ -2,9 +2,7 @@ package dmsg
 
 import (
 	"context"
-	"log"
 	"net"
-	"os"
 	"testing"
 	"time"
 
@@ -21,21 +19,6 @@ const (
 type transportWithError struct {
 	tr  *Transport
 	err error
-}
-
-func TestMain(m *testing.M) {
-	loggingLevel, ok := os.LookupEnv("TEST_LOGGING_LEVEL")
-	if ok {
-		lvl, err := logging.LevelFromString(loggingLevel)
-		if err != nil {
-			log.Fatal(err)
-		}
-		logging.SetLevel(lvl)
-	} else {
-		logging.Disable()
-	}
-
-	os.Exit(m.Run())
 }
 
 func TestClient(t *testing.T) {


### PR DESCRIPTION
Removed TestMain from pkg/dmsg/client_test.go

Closes: #429 