### PR TITLE
Fix data race in SSH

### DIFF
--- a/internal/therealssh/channel.go
+++ b/internal/therealssh/channel.go
@@ -11,6 +11,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/kr/pty"
 
@@ -35,6 +36,8 @@ type SSHChannel struct {
 
 	session  *Session
 	listener *net.UnixListener
+
+	dataChMx sync.Mutex
 	dataCh   chan []byte
 }
 
@@ -249,7 +252,9 @@ func (sshCh *SSHChannel) Close() error {
 	select {
 	case <-sshCh.dataCh:
 	default:
+		sshCh.dataChMx.Lock()
 		close(sshCh.dataCh)
+		sshCh.dataChMx.Unlock()
 	}
 	close(sshCh.msgCh)
 

--- a/internal/therealssh/client.go
+++ b/internal/therealssh/client.go
@@ -135,7 +135,9 @@ func (c *Client) serveConn(conn net.Conn) error {
 			sshCh.msgCh <- data
 		case CmdChannelData:
 			sshCh.dataChMx.Lock()
-			sshCh.dataCh <- data
+			if !sshCh.IsClosed() {
+				sshCh.dataCh <- data
+			}
 			sshCh.dataChMx.Unlock()
 		case CmdChannelServerClose:
 			err = sshCh.Close()

--- a/internal/therealssh/client.go
+++ b/internal/therealssh/client.go
@@ -134,7 +134,9 @@ func (c *Client) serveConn(conn net.Conn) error {
 		case CmdChannelOpenResponse, CmdChannelResponse:
 			sshCh.msgCh <- data
 		case CmdChannelData:
+			sshCh.dataChMx.Lock()
 			sshCh.dataCh <- data
+			sshCh.dataChMx.Unlock()
 		case CmdChannelServerClose:
 			err = sshCh.Close()
 		default:

--- a/internal/therealssh/server.go
+++ b/internal/therealssh/server.go
@@ -126,7 +126,9 @@ func (s *Server) HandleData(remotePK cipher.PubKey, localID uint32, data []byte)
 	}
 
 	channel.dataChMx.Lock()
-	channel.dataCh <- data
+	if !channel.IsClosed() {
+		channel.dataCh <- data
+	}
 	channel.dataChMx.Unlock()
 	return nil
 }

--- a/internal/therealssh/server.go
+++ b/internal/therealssh/server.go
@@ -125,7 +125,9 @@ func (s *Server) HandleData(remotePK cipher.PubKey, localID uint32, data []byte)
 		return errors.New("session is not started")
 	}
 
+	channel.dataChMx.Lock()
 	channel.dataCh <- data
+	channel.dataChMx.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
Fixes #435 . 

Implementation follows the same pattern as in the DMSG transport. Also added `sync.Once` to prevent duplicate `close` calls on channels if the `SSHChannel`'s `Close` gets called more than once accindetally. 