### PR TITLE
[ROUTING] Add 'purpose' fields in transport.Transport and transport.Factory

### DIFF
--- a/cmd/hypervisor/hypervisor.postman_collection.json
+++ b/cmd/hypervisor/hypervisor.postman_collection.json
@@ -564,7 +564,7 @@
         ],
         "body": {
           "mode": "raw",
-          "raw": "{\n\t\"remote_pk\": \"03c497380efd87e19208bb484ee322ede1e091b2a0b653e6d25475f641602376a9\",\n\t\"transport_type\": \"native\",\n\t\"public\": true\n}"
+          "raw": "{\n\t\"remote_pk\": \"03c497380efd87e19208bb484ee322ede1e091b2a0b653e6d25475f641602376a9\",\n\t\"transport_type\": \"native\",\n\t\"purpose\": \"data\",\n\t\"public\": true\n}"
         },
         "url": {
           "raw": "http://localhost:8080/api/nodes/023ab9f45c0eb3625f9848a9ff6822c6d0965a94d3e7955f1869f38153df0e5b64/transports",
@@ -597,7 +597,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n\t\"remote_pk\": \"03c497380efd87e19208bb484ee322ede1e091b2a0b653e6d25475f641602376a9\",\n\t\"transport_type\": \"native\",\n\t\"public\": true\n}"
+              "raw": "{\n\t\"remote_pk\": \"03c497380efd87e19208bb484ee322ede1e091b2a0b653e6d25475f641602376a9\",\n\t\"transport_type\": \"native\",\n\t\"purpose\": \"data\",\n\t\"public\": true\n}"
             },
             "url": {
               "raw": "http://localhost:8080/api/nodes/039337a306ffbd6a7495f79b65aec91ce65756e4fd1cb2cd726840b2eee4fa59c2/transports",

--- a/cmd/skywire-cli/commands/node/transports.go
+++ b/cmd/skywire-cli/commands/node/transports.go
@@ -73,12 +73,14 @@ var tpCmd = &cobra.Command{
 
 var (
 	transportType string
+	purpose       string
 	public        bool
 	timeout       time.Duration
 )
 
 func init() {
 	addTpCmd.Flags().StringVar(&transportType, "type", dmsg.Type, "type of transport to add")
+	addTpCmd.Flags().StringVar(&purpose, "purpose", dmsg.PurposeData, "purpose of transport to add")
 	addTpCmd.Flags().BoolVar(&public, "public", true, "whether to make the transport public")
 	addTpCmd.Flags().DurationVarP(&timeout, "timeout", "t", 0, "if specified, sets an operation timeout")
 }
@@ -89,7 +91,7 @@ var addTpCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(_ *cobra.Command, args []string) {
 		pk := internal.ParsePK("remote-public-key", args[0])
-		tp, err := rpcClient().AddTransport(pk, transportType, public, timeout)
+		tp, err := rpcClient().AddTransport(pk, transportType, purpose, public, timeout)
 		internal.Catch(err)
 		printTransports(tp)
 	},
@@ -109,7 +111,7 @@ var rmTpCmd = &cobra.Command{
 func printTransports(tps ...*visor.TransportSummary) {
 	sortTransports(tps...)
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 5, ' ', tabwriter.TabIndent)
-	_, err := fmt.Fprintln(w, "type\tid\tremote\tmode")
+	_, err := fmt.Fprintln(w, "type\tid\tremote\tmode\tpurpose")
 	internal.Catch(err)
 	for _, tp := range tps {
 		tpMode := "regular"
@@ -117,7 +119,7 @@ func printTransports(tps ...*visor.TransportSummary) {
 			tpMode = "setup"
 		}
 
-		_, err = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", tp.Type, tp.ID, tp.Remote, tpMode)
+		_, err = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", tp.Type, tp.ID, tp.Remote, tpMode, tp.Purpose)
 		internal.Catch(err)
 	}
 	internal.Catch(w.Flush())

--- a/cmd/skywire-cli/commands/tpdisc/root.go
+++ b/cmd/skywire-cli/commands/tpdisc/root.go
@@ -66,11 +66,12 @@ var RootCmd = &cobra.Command{
 
 func printTransportEntries(entries ...*transport.EntryWithStatus) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 5, ' ', tabwriter.TabIndent)
-	_, err := fmt.Fprintln(w, "id\ttype\tpublic\tregistered\tup\tedge1\tedge2\topinion1\topinion2")
+	_, err := fmt.Fprintln(w, "id\ttype\tpurpose\tpublic\tregistered\tup\tedge1\tedge2\topinion1\topinion2")
 	internal.Catch(err)
 	for _, e := range entries {
-		_, err := fmt.Fprintf(w, "%s\t%s\t%t\t%d\t%t\t%s\t%s\t%t\t%t\n",
-			e.Entry.ID, e.Entry.Type, e.Entry.Public, e.Registered, e.IsUp, e.Entry.Edges()[0], e.Entry.Edges()[1], e.Statuses[0], e.Statuses[1])
+		_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%t\t%d\t%t\t%s\t%s\t%t\t%t\n",
+			e.Entry.ID, e.Entry.Type, e.Entry.Purpose, e.Entry.Public, e.Registered, e.IsUp,
+			e.Entry.Edges()[0], e.Entry.Edges()[1], e.Statuses[0], e.Statuses[1])
 		internal.Catch(err)
 	}
 	internal.Catch(w.Flush())

--- a/pkg/hypervisor/hypervisor.go
+++ b/pkg/hypervisor/hypervisor.go
@@ -290,15 +290,16 @@ func (m *Node) getTransports() http.HandlerFunc {
 func (m *Node) postTransport() http.HandlerFunc {
 	return m.withCtx(m.nodeCtx, func(w http.ResponseWriter, r *http.Request, ctx *httpCtx) {
 		var reqBody struct {
-			Remote cipher.PubKey `json:"remote_pk"`
-			TpType string        `json:"transport_type"`
-			Public bool          `json:"public"`
+			Remote  cipher.PubKey `json:"remote_pk"`
+			TpType  string        `json:"transport_type"`
+			Purpose string        `json:"purpose"`
+			Public  bool          `json:"public"`
 		}
 		if err := httputil.ReadJSON(r, &reqBody); err != nil {
 			httputil.WriteJSON(w, r, http.StatusBadRequest, err)
 			return
 		}
-		summary, err := ctx.RPC.AddTransport(reqBody.Remote, reqBody.TpType, reqBody.Public, 30*time.Second)
+		summary, err := ctx.RPC.AddTransport(reqBody.Remote, reqBody.TpType, reqBody.Purpose, reqBody.Public, 30*time.Second)
 		if err != nil {
 			httputil.WriteJSON(w, r, http.StatusInternalServerError, err)
 			return

--- a/pkg/route-finder/client/mock.go
+++ b/pkg/route-finder/client/mock.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/cipher"
 
 	"github.com/skycoin/skywire/pkg/routing"
@@ -34,7 +35,7 @@ func (r *mockClient) PairedRoutes(src, dst cipher.PubKey, minHops, maxHops uint1
 				&routing.Hop{
 					From:      src,
 					To:        dst,
-					Transport: transport.MakeTransportID(src, dst, "", true),
+					Transport: transport.MakeTransportID(src, dst, "", dmsg.PurposeTest, true),
 				},
 			},
 		}, []routing.Route{
@@ -42,7 +43,7 @@ func (r *mockClient) PairedRoutes(src, dst cipher.PubKey, minHops, maxHops uint1
 				&routing.Hop{
 					From:      src,
 					To:        dst,
-					Transport: transport.MakeTransportID(src, dst, "", true),
+					Transport: transport.MakeTransportID(src, dst, "", dmsg.PurposeTest, true),
 				},
 			},
 		}, nil

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -424,7 +424,7 @@ func (r *Router) setupProto(ctx context.Context) (*setup.Protocol, transport.Tra
 	}
 
 	// TODO(evanlinjin): need string constant for tp type.
-	tr, err := r.tm.CreateTransport(ctx, r.config.SetupNodes[0], dmsg.Type, false)
+	tr, err := r.tm.CreateTransport(ctx, r.config.SetupNodes[0], dmsg.Type, dmsg.PurposeSetup, false)
 	if err != nil {
 		return nil, nil, fmt.Errorf("setup transport: %s", err)
 	}

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -78,10 +78,10 @@ func TestRouterForwarding(t *testing.T) {
 		errCh <- r.Serve(context.TODO())
 	}()
 
-	tr1, err := m1.CreateTransport(context.TODO(), pk2, "mock", true)
+	tr1, err := m1.CreateTransport(context.TODO(), pk2, "mock", dmsg.PurposeTest, true)
 	require.NoError(t, err)
 
-	tr3, err := m3.CreateTransport(context.TODO(), pk2, "mock2", true)
+	tr3, err := m3.CreateTransport(context.TODO(), pk2, "mock2", dmsg.PurposeTest, true)
 	require.NoError(t, err)
 
 	rule := routing.ForwardRule(time.Now().Add(time.Hour), 4, tr3.Entry.ID)
@@ -201,7 +201,7 @@ func TestRouterApp(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	tr, err := m1.CreateTransport(context.TODO(), pk2, "mock", true)
+	tr, err := m1.CreateTransport(context.TODO(), pk2, "mock", dmsg.PurposeTest, true)
 	require.NoError(t, err)
 
 	rule := routing.AppRule(time.Now().Add(time.Hour), 4, pk2, 5, 6)
@@ -354,7 +354,7 @@ func TestRouterSetup(t *testing.T) {
 		errCh <- r.Serve(context.TODO())
 	}()
 
-	tr, err := m2.CreateTransport(context.TODO(), pk1, "mock", false)
+	tr, err := m2.CreateTransport(context.TODO(), pk1, "mock", dmsg.PurposeTest, false)
 	require.NoError(t, err)
 	sProto := setup.NewSetupProtocol(tr)
 

--- a/pkg/setup/node.go
+++ b/pkg/setup/node.go
@@ -259,7 +259,7 @@ func (sn *Node) serveTransport(tr transport.Transport) error {
 }
 
 func (sn *Node) connectLoop(on cipher.PubKey, ld routing.LoopData) error {
-	tr, err := sn.tm.CreateTransport(context.Background(), on, dmsg.Type, false)
+	tr, err := sn.tm.CreateTransport(context.Background(), on, dmsg.Type, dmsg.PurposeSetup, false)
 	if err != nil {
 		return fmt.Errorf("transport: %s", err)
 	}
@@ -279,7 +279,7 @@ func (sn *Node) connectLoop(on cipher.PubKey, ld routing.LoopData) error {
 }
 
 func (sn *Node) closeLoop(on cipher.PubKey, ld routing.LoopData) error {
-	tr, err := sn.tm.CreateTransport(context.Background(), on, dmsg.Type, false)
+	tr, err := sn.tm.CreateTransport(context.Background(), on, dmsg.Type, dmsg.PurposeSetup, false)
 	if err != nil {
 		return fmt.Errorf("transport: %s", err)
 	}
@@ -299,7 +299,7 @@ func (sn *Node) closeLoop(on cipher.PubKey, ld routing.LoopData) error {
 }
 
 func (sn *Node) setupRule(pubKey cipher.PubKey, rule routing.Rule) (routeID routing.RouteID, err error) {
-	tr, err := sn.tm.CreateTransport(context.Background(), pubKey, dmsg.Type, false)
+	tr, err := sn.tm.CreateTransport(context.Background(), pubKey, dmsg.Type, dmsg.PurposeSetup, false)
 	if err != nil {
 		err = fmt.Errorf("transport: %s", err)
 		return

--- a/pkg/transport-discovery/client/client_test.go
+++ b/pkg/transport-discovery/client/client_test.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/cipher"
 	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/stretchr/testify/assert"
@@ -40,9 +41,10 @@ var testPubKey, testSecKey = cipher.GenerateKeyPair()
 func newTestEntry() *transport.Entry {
 	pk1, _ := cipher.GenerateKeyPair()
 	entry := &transport.Entry{
-		ID:     transport.MakeTransportID(pk1, testPubKey, "messaging", false),
-		Type:   "messaging",
-		Public: true,
+		ID:      transport.MakeTransportID(pk1, testPubKey, "messaging", dmsg.PurposeTest, false),
+		Type:    "messaging",
+		Purpose: dmsg.PurposeTest,
+		Public:  true,
 	}
 	entry.SetEdges([2]cipher.PubKey{pk1, testPubKey})
 

--- a/pkg/transport/discovery_test.go
+++ b/pkg/transport/discovery_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/cipher"
 
 	"github.com/skycoin/skywire/pkg/transport"
@@ -13,7 +14,7 @@ func ExampleNewDiscoveryMock() {
 	dc := transport.NewDiscoveryMock()
 	pk1, _ := cipher.GenerateKeyPair()
 	pk2, _ := cipher.GenerateKeyPair()
-	entry := &transport.Entry{Type: "mock", EdgeKeys: transport.SortPubKeys(pk1, pk2)}
+	entry := &transport.Entry{Type: "mock", Purpose: dmsg.PurposeTest, EdgeKeys: transport.SortPubKeys(pk1, pk2)}
 
 	sEntry := &transport.SignedEntry{Entry: entry}
 

--- a/pkg/transport/dmsg/client.go
+++ b/pkg/transport/dmsg/client.go
@@ -42,27 +42,12 @@ func (c *Client) Accept(ctx context.Context) (transport.Transport, error) {
 }
 
 // Dial is a wrapper type for "github.com/skycoin/dmsg".Dial
-func (c *Client) Dial(ctx context.Context, remote cipher.PubKey) (transport.Transport, error) {
-	tp, err := c.Client.Dial(ctx, remote)
+func (c *Client) Dial(ctx context.Context, remote cipher.PubKey, purpose string) (transport.Transport, error) {
+	tp, err := c.Client.Dial(ctx, remote, purpose)
 	if err != nil {
 		return nil, err
 	}
 	return NewTransport(tp), nil
-}
-
-// Close is a wrapper type for "github.com/skycoin/dmsg".Close
-func (c *Client) Close() error {
-	return c.Client.Close()
-}
-
-// Local is a wrapper type for "github.com/skycoin/dmsg".Local
-func (c *Client) Local() cipher.PubKey {
-	return c.Client.Local()
-}
-
-// Type is a wrapper type for "github.com/skycoin/dmsg".Type
-func (c *Client) Type() string {
-	return c.Client.Type()
 }
 
 // SetLogger is a wrapper type for "github.com/skycoin/dmsg".SetLogger

--- a/pkg/transport/dmsg/transport.go
+++ b/pkg/transport/dmsg/transport.go
@@ -1,12 +1,19 @@
 package dmsg
 
 import (
-	"time"
-
 	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/cipher"
 
 	"github.com/skycoin/skywire/pkg/transport"
+)
+
+const (
+	// PurposeData means that transport is used for data transmission.
+	PurposeData = dmsg.PurposeData
+	// PurposeSetup means that transport is used for setup nodes.
+	PurposeSetup = dmsg.PurposeSetup
+	// PurposeTest means that transport is used for tests.
+	PurposeTest = dmsg.PurposeTest
 )
 
 // Transport is a wrapper type for "github.com/skycoin/dmsg".Transport
@@ -19,32 +26,7 @@ func NewTransport(tp *dmsg.Transport) *Transport {
 	return &Transport{Transport: tp}
 }
 
-// Read is a wrapper for "github.com/skycoin/dmsg".(*Transport).Read
-func (tp *Transport) Read(p []byte) (n int, err error) {
-	return tp.Transport.Read(p)
-}
-
-// Write is a wrapper for "github.com/skycoin/dmsg".(*Transport).Write
-func (tp *Transport) Write(p []byte) (n int, err error) {
-	return tp.Transport.Write(p)
-}
-
-// Close is a wrapper for "github.com/skycoin/dmsg".(*Transport).Close
-func (tp *Transport) Close() error {
-	return tp.Transport.Close()
-}
-
 // Edges returns sorted edges of transport
 func (tp *Transport) Edges() [2]cipher.PubKey {
 	return transport.SortPubKeys(tp.LocalPK(), tp.RemotePK())
-}
-
-// SetDeadline is a wrapper for "github.com/skycoin/dmsg".(*Transport).SetDeadline
-func (tp *Transport) SetDeadline(t time.Time) error {
-	return tp.Transport.SetDeadline(t)
-}
-
-// Type is a wrapper for "github.com/skycoin/dmsg".(*Transport).Type
-func (tp *Transport) Type() string {
-	return tp.Transport.Type()
 }

--- a/pkg/transport/entry.go
+++ b/pkg/transport/entry.go
@@ -20,17 +20,21 @@ type Entry struct {
 	// Type represents the transport type.
 	Type string `json:"type"`
 
+	// Purpose represents the transport purpose.
+	Purpose string `json:"purpose"`
+
 	// Public determines whether the transport is to be exposed to other nodes or not.
 	// Public transports are to be registered in the Transport Discovery.
 	Public bool `json:"public"`
 }
 
 // NewEntry constructs *Entry
-func NewEntry(edgeA, edgeB cipher.PubKey, tpType string, public bool) *Entry {
+func NewEntry(edgeA, edgeB cipher.PubKey, tpType, purpose string, public bool) *Entry {
 	return &Entry{
-		ID:       MakeTransportID(edgeA, edgeB, tpType, public),
+		ID:       MakeTransportID(edgeA, edgeB, tpType, purpose, public),
 		EdgeKeys: SortPubKeys(edgeA, edgeB),
 		Type:     tpType,
+		Purpose:  purpose,
 		Public:   public,
 	}
 }
@@ -42,7 +46,7 @@ func (e *Entry) Edges() [2]cipher.PubKey {
 
 // SetEdges sets edges of Entry
 func (e *Entry) SetEdges(edges [2]cipher.PubKey) {
-	e.ID = MakeTransportID(edges[0], edges[1], e.Type, e.Public)
+	e.ID = MakeTransportID(edges[0], edges[1], e.Type, e.Purpose, e.Public)
 	e.EdgeKeys = SortPubKeys(edges[0], edges[1])
 }
 
@@ -55,6 +59,7 @@ func (e *Entry) String() string {
 		res += fmt.Sprintf("visibility: private\n")
 	}
 	res += fmt.Sprintf("\ttype: %s\n", e.Type)
+	res += fmt.Sprintf("\tpurpose: %s\n", e.Purpose)
 	res += fmt.Sprintf("\tid: %s\n", e.ID)
 	res += fmt.Sprintf("\tedges:\n")
 	res += fmt.Sprintf("\t\tedge 1: %s\n", e.Edges()[0])
@@ -68,9 +73,11 @@ func (e *Entry) ToBinary() []byte {
 	edges := e.Edges()
 	return append(
 		append(
-			append(e.ID[:], edges[0][:]...),
-			edges[1][:]...),
-		[]byte(e.Type)...)
+			append(
+				append(e.ID[:], edges[0][:]...),
+				edges[1][:]...),
+			[]byte(e.Type)...),
+		[]byte(e.Purpose)...)
 }
 
 // Signature returns signature for Entry calculated from binary

--- a/pkg/transport/entry_test.go
+++ b/pkg/transport/entry_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/cipher"
 
 	"github.com/skycoin/skywire/pkg/transport"
@@ -16,8 +17,8 @@ func ExampleNewEntry() {
 	pkA, _ := cipher.GenerateKeyPair()
 	pkB, _ := cipher.GenerateKeyPair()
 
-	entryAB := transport.NewEntry(pkA, pkB, "", true)
-	entryBA := transport.NewEntry(pkB, pkA, "", true)
+	entryAB := transport.NewEntry(pkA, pkB, "", dmsg.PurposeTest, true)
+	entryBA := transport.NewEntry(pkB, pkA, "", dmsg.PurposeTest, true)
 
 	if entryAB.ID == entryBA.ID {
 		fmt.Println("entryAB.ID == entryBA.ID")
@@ -37,6 +38,7 @@ func ExampleEntry_Edges() {
 		ID:       uuid.UUID{},
 		EdgeKeys: [2]cipher.PubKey{pkA, pkB},
 		Type:     "",
+		Purpose:  dmsg.PurposeTest,
 		Public:   true,
 	}
 
@@ -44,6 +46,7 @@ func ExampleEntry_Edges() {
 		ID:       uuid.UUID{},
 		EdgeKeys: [2]cipher.PubKey{pkB, pkA},
 		Type:     "",
+		Purpose:  dmsg.PurposeTest,
 		Public:   true,
 	}
 
@@ -86,7 +89,7 @@ func ExampleSignedEntry_Sign() {
 	pkA, skA := cipher.GenerateKeyPair()
 	pkB, skB := cipher.GenerateKeyPair()
 
-	entry := transport.NewEntry(pkA, pkB, "mock", true)
+	entry := transport.NewEntry(pkA, pkB, "mock", dmsg.PurposeTest, true)
 	sEntry := &transport.SignedEntry{Entry: entry}
 
 	if sEntry.Signatures[0].Null() && sEntry.Signatures[1].Null() {
@@ -120,7 +123,7 @@ func ExampleSignedEntry_Signature() {
 	pkA, skA := cipher.GenerateKeyPair()
 	pkB, skB := cipher.GenerateKeyPair()
 
-	entry := transport.NewEntry(pkA, pkB, "mock", true)
+	entry := transport.NewEntry(pkA, pkB, "mock", dmsg.PurposeTest, true)
 	sEntry := &transport.SignedEntry{Entry: entry}
 	if ok := sEntry.Sign(pkA, skA); !ok {
 		fmt.Println("Error signing sEntry with (pkA,skA)")

--- a/pkg/transport/handshake.go
+++ b/pkg/transport/handshake.go
@@ -30,9 +30,10 @@ func (handshake settlementHandshake) Do(tm *Manager, tr Transport, timeout time.
 
 func makeEntry(tp Transport, public bool) *Entry {
 	return &Entry{
-		ID:       MakeTransportID(tp.Edges()[0], tp.Edges()[1], tp.Type(), public),
+		ID:       MakeTransportID(tp.Edges()[0], tp.Edges()[1], tp.Type(), tp.Purpose(), public),
 		EdgeKeys: tp.Edges(),
 		Type:     tp.Type(),
+		Purpose:  tp.Purpose(),
 		Public:   public,
 	}
 }
@@ -40,7 +41,8 @@ func makeEntry(tp Transport, public bool) *Entry {
 func compareEntries(expected, received *Entry, checkPublic bool) error {
 	if !checkPublic {
 		expected.Public = received.Public
-		expected.ID = MakeTransportID(expected.EdgeKeys[0], expected.EdgeKeys[1], expected.Type, expected.Public)
+		expected.ID = MakeTransportID(expected.EdgeKeys[0], expected.EdgeKeys[1], expected.Type, expected.Purpose,
+			expected.Public)
 	}
 	if expected.ID != received.ID {
 		return errors.New("received entry's 'tp_id' is not of expected")
@@ -50,6 +52,9 @@ func compareEntries(expected, received *Entry, checkPublic bool) error {
 	}
 	if expected.Type != received.Type {
 		return errors.New("received entry's 'type' is not of expected")
+	}
+	if expected.Purpose != received.Purpose {
+		return errors.New("received entry's 'purpose' is not of expected")
 	}
 	if expected.Public != received.Public {
 		return errors.New("received entry's 'public' is not of expected")

--- a/pkg/transport/handshake_test.go
+++ b/pkg/transport/handshake_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/cipher"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,8 +33,8 @@ func newHsMockEnv() *hsMockEnv {
 	pk2, sk2 := cipher.GenerateKeyPair()
 
 	in, out := net.Pipe()
-	tr1 := NewMockTransport(in, pk1, pk2)
-	tr2 := NewMockTransport(out, pk2, pk1)
+	tr1 := NewMockTransport(in, pk1, pk2, dmsg.PurposeTest)
+	tr2 := NewMockTransport(out, pk2, pk1, dmsg.PurposeTest)
 
 	m1, err1 := NewManager(&ManagerConfig{PubKey: pk1, SecKey: sk1, DiscoveryClient: client})
 	m2, err2 := NewManager(&ManagerConfig{PubKey: pk2, SecKey: sk2, DiscoveryClient: client})
@@ -231,10 +232,12 @@ func TestSettlementHandshakeExistingTransport(t *testing.T) {
 	require.NoError(t, mockEnv.err2)
 
 	tpType := "mock"
+	purpose := dmsg.PurposeTest
 	entry := &Entry{
-		ID:       MakeTransportID(mockEnv.pk1, mockEnv.pk2, tpType, true),
+		ID:       MakeTransportID(mockEnv.pk1, mockEnv.pk2, tpType, purpose, true),
 		EdgeKeys: SortPubKeys(mockEnv.pk1, mockEnv.pk2),
 		Type:     tpType,
+		Purpose:  purpose,
 		Public:   true,
 	}
 

--- a/pkg/transport/manager_test.go
+++ b/pkg/transport/manager_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/cipher"
 	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/stretchr/testify/assert"
@@ -83,7 +84,7 @@ func TestTransportManager(t *testing.T) {
 		}
 	}()
 
-	tr2, err := m2.CreateTransport(context.TODO(), pk1, "mock", true)
+	tr2, err := m2.CreateTransport(context.TODO(), pk1, "mock", dmsg.PurposeTest, true)
 	require.NoError(t, err)
 
 	time.Sleep(time.Second)
@@ -151,7 +152,7 @@ func TestTransportManagerReEstablishTransports(t *testing.T) {
 	m2, err := NewManager(c2, f2)
 	require.NoError(t, err)
 
-	tr2, err := m2.CreateTransport(context.TODO(), pk1, "mock", true)
+	tr2, err := m2.CreateTransport(context.TODO(), pk1, "mock", dmsg.PurposeTest, true)
 	require.NoError(t, err)
 
 	tr1 := m1.Transport(tr2.Entry.ID)
@@ -214,7 +215,7 @@ func TestTransportManagerLogs(t *testing.T) {
 	m2, err := NewManager(c2, f2)
 	require.NoError(t, err)
 
-	tr2, err := m2.CreateTransport(context.TODO(), pk1, "mock", true)
+	tr2, err := m2.CreateTransport(context.TODO(), pk1, "mock", dmsg.PurposeTest, true)
 	require.NoError(t, err)
 
 	time.Sleep(100 * time.Millisecond)
@@ -271,31 +272,33 @@ func ExampleMakeTransportID() {
 	keyA, _ := cipher.GenerateKeyPair()
 	keyB, _ := cipher.GenerateKeyPair()
 
-	uuidAB := MakeTransportID(keyA, keyB, "type", true)
+	uuidAB := MakeTransportID(keyA, keyB, "type", dmsg.PurposeTest, true)
 
 	for i := 0; i < 256; i++ {
-		if MakeTransportID(keyA, keyB, "type", true) != uuidAB {
+		if MakeTransportID(keyA, keyB, "type", dmsg.PurposeTest, true) != uuidAB {
 			fmt.Println("uuid is unstable")
 			break
 		}
 	}
 	fmt.Printf("uuid is stable\n")
 
-	uuidBA := MakeTransportID(keyB, keyA, "type", true)
+	uuidBA := MakeTransportID(keyB, keyA, "type", dmsg.PurposeTest, true)
 	if uuidAB == uuidBA {
 		fmt.Println("uuid is bidirectional")
 	} else {
 		fmt.Printf("keyA = %v\n keyB=%v\n uuidAB=%v\n uuidBA=%v\n", keyA, keyB, uuidAB, uuidBA)
 	}
 
-	_ = MakeTransportID(keyA, keyA, "type", true) // works for equal keys
+	_ = MakeTransportID(keyA, keyA, "type", dmsg.PurposeTest, true) // works for equal keys
 	fmt.Println("works for equal keys")
 
-	if MakeTransportID(keyA, keyB, "type", true) != MakeTransportID(keyA, keyB, "another_type", true) {
+	if MakeTransportID(keyA, keyB, "type", dmsg.PurposeTest, true) !=
+		MakeTransportID(keyA, keyB, "another_type", dmsg.PurposeTest, true) {
 		fmt.Println("uuid is different for different types")
 	}
 
-	if MakeTransportID(keyA, keyB, "type", true) != MakeTransportID(keyA, keyB, "type", false) {
+	if MakeTransportID(keyA, keyB, "type", dmsg.PurposeTest, true) !=
+		MakeTransportID(keyA, keyB, "type", dmsg.PurposeTest, false) {
 		fmt.Println("uuid is different for public and private transports")
 	}
 
@@ -315,7 +318,7 @@ func ExampleManager_CreateTransport() {
 			return
 		}
 
-		mtrAB, err := mgrA.CreateTransport(context.TODO(), pkB, "mock", true)
+		mtrAB, err := mgrA.CreateTransport(context.TODO(), pkB, "mock", dmsg.PurposeTest, true)
 		if err != nil {
 			fmt.Printf("Manager.CreateTransport failed on iteration %v with: %v\n", i, err)
 			return

--- a/pkg/transport/tcp_transport.go
+++ b/pkg/transport/tcp_transport.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/cipher"
 )
 
@@ -41,11 +42,11 @@ func (f *TCPFactory) Accept(ctx context.Context) (Transport, error) {
 		return nil, ErrUnknownRemote
 	}
 
-	return &TCPTransport{conn, [2]cipher.PubKey{f.lpk, rpk}}, nil
+	return &TCPTransport{conn, [2]cipher.PubKey{f.lpk, rpk}, dmsg.PurposeTest}, nil
 }
 
 // Dial initiates a Transport with a remote node.
-func (f *TCPFactory) Dial(ctx context.Context, remote cipher.PubKey) (Transport, error) {
+func (f *TCPFactory) Dial(ctx context.Context, remote cipher.PubKey, purpose string) (Transport, error) {
 	raddr := f.pkt.RemoteAddr(remote)
 	if raddr == nil {
 		return nil, ErrUnknownRemote
@@ -56,7 +57,7 @@ func (f *TCPFactory) Dial(ctx context.Context, remote cipher.PubKey) (Transport,
 		return nil, err
 	}
 
-	return &TCPTransport{conn, [2]cipher.PubKey{f.lpk, remote}}, nil
+	return &TCPTransport{conn, [2]cipher.PubKey{f.lpk, remote}, purpose}, nil
 }
 
 // Close implements io.Closer
@@ -80,7 +81,8 @@ func (f *TCPFactory) Type() string {
 // TCPTransport implements Transport over TCP connection.
 type TCPTransport struct {
 	*net.TCPConn
-	edges [2]cipher.PubKey
+	edges   [2]cipher.PubKey
+	purpose string
 }
 
 // Edges returns the  TCPTransport edges.
@@ -91,6 +93,11 @@ func (tr *TCPTransport) Edges() [2]cipher.PubKey {
 // Type returns the string representation of the transport type.
 func (tr *TCPTransport) Type() string {
 	return "tcp"
+}
+
+// Purpose returns the string representation of the transport purpose.
+func (tr *TCPTransport) Purpose() string {
+	return tr.purpose
 }
 
 // PubKeyTable provides translation between remote PubKey and TCPAddr.

--- a/pkg/transport/tcp_transport_test.go
+++ b/pkg/transport/tcp_transport_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/cipher"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -53,7 +54,7 @@ func TestTCPFactory(t *testing.T) {
 	assert.Equal(t, "tcp", f2.Type())
 	assert.Equal(t, pk2, f2.Local())
 
-	tr, err := f2.Dial(context.TODO(), pk1)
+	tr, err := f2.Dial(context.TODO(), pk1, dmsg.PurposeTest)
 	require.NoError(t, err)
 	assert.Equal(t, "tcp", tr.Type())
 

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -34,6 +34,9 @@ type Transport interface {
 
 	// Type returns the string representation of the transport type.
 	Type() string
+
+	// Purpose returns the string representation of the transport purpose.
+	Purpose() string
 }
 
 // Factory generates Transports of a certain type.
@@ -43,7 +46,7 @@ type Factory interface {
 	Accept(ctx context.Context) (Transport, error)
 
 	// Dial initiates a Transport with a remote node.
-	Dial(ctx context.Context, remote cipher.PubKey) (Transport, error)
+	Dial(ctx context.Context, remote cipher.PubKey, purpose string) (Transport, error)
 
 	// Close implements io.Closer
 	Close() error
@@ -55,18 +58,18 @@ type Factory interface {
 	Type() string
 }
 
-// MakeTransportID generates uuid.UUID from pair of keys + type + public
+// MakeTransportID generates uuid.UUID from pair of keys + type + purpose + public
 // Generated uuid is:
 // - always the same for a given pair
 // - GenTransportUUID(keyA,keyB) == GenTransportUUID(keyB, keyA)
-func MakeTransportID(keyA, keyB cipher.PubKey, tpType string, public bool) uuid.UUID {
+func MakeTransportID(keyA, keyB cipher.PubKey, tpType, purpose string, public bool) uuid.UUID {
 	keys := SortPubKeys(keyA, keyB)
 	if public {
 		return uuid.NewSHA1(uuid.UUID{},
-			append(append(append(keys[0][:], keys[1][:]...), []byte(tpType)...), 1))
+			append(append(append(append(keys[0][:], keys[1][:]...), []byte(tpType)...), []byte(purpose)...), 1))
 	}
 	return uuid.NewSHA1(uuid.UUID{},
-		append(append(append(keys[0][:], keys[1][:]...), []byte(tpType)...), 0))
+		append(append(append(append(keys[0][:], keys[1][:]...), []byte(tpType)...), []byte(purpose)...), 0))
 }
 
 // SortPubKeys sorts keys so that least-significant comes first

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -43,6 +43,7 @@ type TransportSummary struct {
 	Local   cipher.PubKey       `json:"local_pk"`
 	Remote  cipher.PubKey       `json:"remote_pk"`
 	Type    string              `json:"type"`
+	Purpose string              `json:"purpose"`
 	Log     *transport.LogEntry `json:"log,omitempty"`
 	IsSetup bool                `json:"is_setup"`
 }
@@ -194,6 +195,7 @@ func (r *RPC) Transport(in *uuid.UUID, out *TransportSummary) error {
 type AddTransportIn struct {
 	RemotePK cipher.PubKey
 	TpType   string
+	Purpose  string
 	Public   bool
 	Timeout  time.Duration
 }
@@ -207,7 +209,7 @@ func (r *RPC) AddTransport(in *AddTransportIn, out *TransportSummary) error {
 		defer cancel()
 	}
 
-	tp, err := r.node.tm.CreateTransport(ctx, in.RemotePK, in.TpType, in.Public)
+	tp, err := r.node.tm.CreateTransport(ctx, in.RemotePK, in.TpType, in.Purpose, in.Public)
 	if err != nil {
 		return err
 	}

--- a/pkg/visor/rpc_test.go
+++ b/pkg/visor/rpc_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/cipher"
 	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/stretchr/testify/assert"
@@ -112,7 +113,7 @@ func TestRPC(t *testing.T) {
 		require.NoError(t, <-errCh)
 	}()
 
-	_, err = tm2.CreateTransport(context.TODO(), pk1, "mock", true)
+	_, err = tm2.CreateTransport(context.TODO(), pk1, "mock", dmsg.PurposeTest, true)
 	require.NoError(t, err)
 
 	apps := []AppConfig{

--- a/vendor/github.com/skycoin/dmsg/server.go
+++ b/vendor/github.com/skycoin/dmsg/server.go
@@ -209,11 +209,11 @@ func (c *ServerConn) forwardFrame(ft FrameType, id uint16, p []byte) (*NextConn,
 
 // nolint:unparam
 func (c *ServerConn) handleRequest(ctx context.Context, getLink getConnFunc, id uint16, p []byte) (*NextConn, byte, bool) {
-	initPK, respPK, ok := splitPKs(p)
-	if !ok || initPK != c.PK() {
+	payload, err := unmarshalHandshakePayload(p)
+	if err != nil || payload.InitPK != c.PK() {
 		return nil, 0, false
 	}
-	respL, ok := getLink(respPK)
+	respL, ok := getLink(payload.RespPK)
 	if !ok {
 		return nil, 0, false
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -62,7 +62,7 @@ github.com/prometheus/procfs/internal/fs
 # github.com/sirupsen/logrus v1.4.2
 github.com/sirupsen/logrus/hooks/syslog
 github.com/sirupsen/logrus
-# github.com/skycoin/dmsg v0.0.0-20190719095515-52043626400c
+# github.com/skycoin/dmsg v0.0.0-20190719095515-52043626400c => ../dmsg
 github.com/skycoin/dmsg/cipher
 github.com/skycoin/dmsg
 github.com/skycoin/dmsg/disc


### PR DESCRIPTION
Closes #486 

Changes:

- Added a purpose field to `Transport` type
- Added a purpose parameter to `Dial` method

NOTE: This PR breaks compatibility with `master` branch of `dmsg` and therefore needs to be merged simultaneously with https://github.com/skycoin/dmsg/pull/26.