### PR TITLE
Update testnet_rules.md

### DIFF
--- a/testnet_rules.md
+++ b/testnet_rules.md
@@ -69,7 +69,7 @@ There are two different reward categories for official miners:
 * official Skyminers first & second batch - **not sold through** the hardware store 
 * official Skyminers new batches - **sold through** the [hardware store](https://store.skycoin.net)
 
-<em>Faulty orange pi prime's of official Skyminers will be rewarded regardless of your uptime until you receive a replacement. If the replacement doesn't arrive in time for you to make the uptime requirement because it arrived on short notice or not on the schedule at all you will be rewarded as well. Since we are taking care of this manually you are requested to contact one of our team members on Telegram (@Paperstream @asxtree) or at store.skycoin.net/pages/support</em>
+<em>Faulty orange pi prime's/routers of official Skyminers will be rewarded regardless of your uptime until you receive a replacement. If the replacement doesn't arrive in time for you to make the uptime requirement because it arrived on short notice or not on the schedule at all you will be rewarded as well. Since we are taking care of this manually you are requested to contact one of our team members on Telegram (@Paperstream @asxtree) or at store.skycoin.net/pages/support</em>
 
 <h4>Official Skyminers -  First & Second Batch</h4>
 <div align="center"><em><u>We are currently revising the reward strucure for our early supporters. Details of the rewards going forward will be announced very soon. </u></em></div><br/>
@@ -79,9 +79,9 @@ Rewards are being paid on a node by node basis. The total amount of rewards is l
 * Rewards are being calculated on a node by node basis
 * The total pool size is being divided evenly between all nodes eligible for receiving rewards. This implies that you will receive less than 12 Skycoin per-node rewards in case the pool size would be surpassed. 
 
-#### Reward Details - June
-The official reward pool size for June was 24,000 Skycoin:
-* **9.788 (9.787928221859707) Skycoin / node ; 78.303 Skycoin per 8 nodes**
+#### Reward Details - July
+The official reward pool size for July was 24,000 Skycoin:
+* **9.604 (9.603841536614645) Skycoin / node ; 76.831 Skycoin per 8 nodes**
 </div>
 <br>
 
@@ -95,6 +95,8 @@ You will receive a fixed Skycoin payment per month <b>in addition</b> to any tra
 Fixed Skycoin payments per month = USD Miner Price / 24 = $83.30 USD.</strong></div>
 <br/>
 <div align="center"><i>Your fixed Skycoin payments are dependent on your the uptime of your nodes. All of your 8 nodes must meet the uptime requirement for you to receive the full $83.30 USD, it is therefore <strong>superimportant to keep your nodes online.</strong></i></div>
+<br>
+<em>Faulty orange pi prime's/routers of official Skyminers will be rewarded regardless of your uptime until you receive a replacement. If the replacement doesn't arrive in time for you to make the uptime requirement because it arrived on short notice or not on the schedule at all you will be rewarded as well. Since we are taking care of this manually you are requested to contact one of our team members on Telegram (@Paperstream @asxtree) or at store.skycoin.net/pages/support</em>
 
 Summary:
 * You are eligible to receive 24 fixed Skycoin payments ($83.30 USD)
@@ -109,19 +111,19 @@ We are calculating the underlying Skycoin price for your rewards based on the mo
 - 30 day length
 - starting on the 1st day of the subsequent month at 00:00
 
-#### Reward Details - June
+#### Reward Details - July
 Rewards are being paid on a node by node basis. The total amount you may earn is 8 per node rewards for each miner.
-The per node rewards for June are as follows:
-- Skycoin price $1.90994003
-- **5.452 (5.451741853905224) Skycoin per node reward; 43.614 Skycoin per 8 nodes**
+The per node rewards for July are as follows:
+- Skycoin price $1.15942020
+- **8.981 (8.9807819460106) Skycoin per node reward; 71.846 Skycoin per 8 nodes**
 - Skycoin per node reward equals ~ $USD 10.4125 
 
 ***
 
 ### DIY Skyminers
 
-Rewards are being paid on a node by node basis. The total amount of rewards is limited by a pool size that is subject to change. The DIY pool size for June was 16,000 Skycoin:
-* **2.875 (2.874595759971254) Skycoin / node with a maximum of 8 nodes; 22.997 Skycoin maximum**
+Rewards are being paid on a node by node basis. The total amount of rewards is limited by a pool size that is subject to change. The DIY pool size for July was 16,000 Skycoin:
+* **2.797 (2.7967138612130746) Skycoin / node with a maximum of 8 nodes; 22.374 Skycoin maximum**
 * As soon as the total amount of rewards of all eligible nodes would be surpassed the pool size, we will adjust the rewards as follows: 
 	* The Skycoin in the pool will be evenly split up between all nodes which are eligible for rewards. 
 	* The maximum amount of Skycoin that any node can receive is 6 (six) Skycoin.


### PR DESCRIPTION
July updates:
- Skywire testnet rewards
- include explicit note that faulty boards + routers are being rewarded if they arrived DOA (until now only boards were mentioned)