### PR TITLE
Fix/tcp-transport with correct laddr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,10 @@ install:
   - go get -u github.com/FiloSottile/vendorcheck
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.17.1
 
+before_script:
+  - ci_scripts/create-ip-aliases.sh
+
 script:
-  - make check
+  - make lint
+  - make test
+  - make test-no-ci

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ DOCKER_NETWORK?=SKYNET
 DOCKER_NODE?=SKY01
 DOCKER_OPTS?=GO111MODULE=on GOOS=linux # go options for compiling for docker container
 TEST_OPTS?=-race -tags no_ci -cover -timeout=5m
+TEST_OPTS_NOCI?=-race -cover -timeout=5m -v
 BUILD_OPTS?=-race
 
 check: lint test ## Run linters and tests
@@ -63,6 +64,10 @@ test: ## Run tests
 	-go clean -testcache &>/dev/null
 	${OPTS} go test ${TEST_OPTS} ./internal/...
 	${OPTS} go test ${TEST_OPTS} ./pkg/...
+
+test-no-ci: ## Run no_ci tests
+	-go clean -testcache
+	${OPTS} go test ${TEST_OPTS_NOCI} ./pkg/transport/... -run "TCP|PubKeyTable"
 
 install-linters: ## Install linters
 	- VERSION=1.17.1 ./ci_scripts/install-golangci-lint.sh 

--- a/ci_scripts/create-ip-aliases.sh
+++ b/ci_scripts/create-ip-aliases.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+if [[ "$OSTYPE" == "linux-gnu" ]]; then     
+    for ((i=1; i<=255; i++)) 
+    do 
+        ip addr add 12.12.12.$i/32 dev lo 
+    done
+elif [[ "$OSTYPE" == "darwin" ]]; then 
+    for ((i=1; i<=255; i++))
+    do 
+    ip addr add 12.12.12.$i/32 dev lo0
+    done
+fi

--- a/internal/testhelpers/testhelpers.go
+++ b/internal/testhelpers/testhelpers.go
@@ -2,7 +2,10 @@
 package testhelpers
 
 import (
+	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 const timeout = 5 * time.Second
@@ -15,5 +18,12 @@ func NoErrorWithinTimeout(ch <-chan error) error {
 		return err
 	case <-time.After(timeout):
 		return nil
+	}
+}
+
+// NoErrorN performs require.NoError on multiple errors
+func NoErrorN(t *testing.T, errs ...error) {
+	for _, err := range errs {
+		require.NoError(t, err)
 	}
 }

--- a/mod.go
+++ b/mod.go
@@ -1,0 +1,1 @@
+package skywire

--- a/pkg/transport/tcp_transport.go
+++ b/pkg/transport/tcp_transport.go
@@ -1,9 +1,12 @@
+// +build !no_ci
+
 package transport
 
 import (
 	"bufio"
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -18,45 +21,76 @@ var ErrUnknownRemote = errors.New("unknown remote")
 
 // TCPFactory implements Factory over TCP connection.
 type TCPFactory struct {
-	l   *net.TCPListener
-	lpk cipher.PubKey
-	pkt PubKeyTable
+	Pk      cipher.PubKey
+	PkTable PubKeyTable
+	Lsr     *net.TCPListener
 }
 
-// NewTCPFactory constructs a new TCP Factory.
-func NewTCPFactory(lpk cipher.PubKey, pkt PubKeyTable, l *net.TCPListener) Factory {
-	return &TCPFactory{l, lpk, pkt}
+// NewTCPFactory constructs a new TCP Factory
+func NewTCPFactory(pk cipher.PubKey, pubkeysFile string, tcpAddr string) (Factory, error) {
+
+	pkTbl, err := FilePubKeyTable(pubkeysFile)
+	if err != nil {
+		return nil, fmt.Errorf("error %v reading %v", err, pubkeysFile)
+	}
+
+	addr, err := net.ResolveTCPAddr("tcp", tcpAddr)
+	if err != nil {
+		return nil, fmt.Errorf("error %v resolving %v", err, tcpAddr)
+	}
+
+	tcpListener, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("error %v listening %v", err, tcpAddr)
+	}
+
+	return &TCPFactory{pk, pkTbl, tcpListener}, nil
 }
 
 // Accept accepts a remotely-initiated Transport.
 func (f *TCPFactory) Accept(ctx context.Context) (Transport, error) {
-	conn, err := f.l.AcceptTCP()
+	conn, err := f.Lsr.AcceptTCP()
 	if err != nil {
 		return nil, err
 	}
 
 	raddr := conn.RemoteAddr().(*net.TCPAddr)
-	rpk := f.pkt.RemotePK(raddr.IP)
+	rpk := f.PkTable.RemotePK(raddr.String())
 	if rpk.Null() {
-		return nil, ErrUnknownRemote
+		return nil, fmt.Errorf("error: %v, raddr: %v, rpk: %v", ErrUnknownRemote, raddr.String(), rpk)
 	}
 
-	return &TCPTransport{conn, f.lpk, rpk}, nil
+	// return &TCPTransport{conn, [2]cipher.PubKey{f.Pk, rpk}}, nil
+	return &TCPTransport{conn, f.Pk, rpk}, nil
 }
 
 // Dial initiates a Transport with a remote node.
 func (f *TCPFactory) Dial(ctx context.Context, remote cipher.PubKey) (Transport, error) {
-	raddr := f.pkt.RemoteAddr(remote)
-	if raddr == nil {
+	addr := f.PkTable.RemoteAddr(remote)
+	if addr == "" {
 		return nil, ErrUnknownRemote
 	}
 
-	conn, err := net.DialTCP("tcp", nil, raddr)
+	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
 	if err != nil {
 		return nil, err
 	}
 
-	return &TCPTransport{conn, f.lpk, remote}, nil
+	lsnAddr, err := net.ResolveTCPAddr("tcp", f.Lsr.Addr().String())
+	if err != nil {
+		return nil, fmt.Errorf("error in resolving local address")
+	}
+	locAddr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%v:%v", lsnAddr.IP.String(), "0"))
+	if err != nil {
+		return nil, fmt.Errorf("error in constructing local address ")
+	}
+
+	conn, err := net.DialTCP("tcp", locAddr, tcpAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TCPTransport{conn, f.Pk, remote}, nil
 }
 
 // Close implements io.Closer
@@ -64,17 +98,17 @@ func (f *TCPFactory) Close() error {
 	if f == nil {
 		return nil
 	}
-	return f.l.Close()
+	return f.Lsr.Close()
 }
 
 // Local returns the local public key.
 func (f *TCPFactory) Local() cipher.PubKey {
-	return f.lpk
+	return f.Pk
 }
 
 // Type returns the Transport type.
 func (f *TCPFactory) Type() string {
-	return "tcp"
+	return "tcp-transport"
 }
 
 // TCPTransport implements Transport over TCP connection.
@@ -101,35 +135,52 @@ func (tr *TCPTransport) Type() string {
 
 // PubKeyTable provides translation between remote PubKey and TCPAddr.
 type PubKeyTable interface {
-	RemoteAddr(remotePK cipher.PubKey) *net.TCPAddr
-	RemotePK(remoteIP net.IP) cipher.PubKey
+	RemoteAddr(remotePK cipher.PubKey) string
+	RemotePK(address string) cipher.PubKey
+	Count() int
 }
 
-type inMemoryPKTable struct {
-	entries map[cipher.PubKey]*net.TCPAddr
+type memPKTable struct {
+	entries map[cipher.PubKey]string
+	reverse map[string]cipher.PubKey
 }
 
-// InMemoryPubKeyTable returns in memory implementation of the PubKeyTable.
-func InMemoryPubKeyTable(entries map[cipher.PubKey]*net.TCPAddr) PubKeyTable {
-	return &inMemoryPKTable{entries}
+func memoryPubKeyTable(entries map[cipher.PubKey]string) *memPKTable {
+	reverse := make(map[string]cipher.PubKey)
+	for k, v := range entries {
+		addr, err := net.ResolveTCPAddr("tcp", v)
+		if err != nil {
+			panic("error in resolving address")
+		}
+		reverse[addr.IP.String()] = k
+	}
+	return &memPKTable{entries, reverse}
 }
 
-func (t *inMemoryPKTable) RemoteAddr(remotePK cipher.PubKey) *net.TCPAddr {
+// MemoryPKTable returns in memory implementation of the PubKeyTable.
+func MemoryPubKeyTable(entries map[cipher.PubKey]string) PubKeyTable {
+	return memoryPubKeyTable(entries)
+}
+
+func (t *memPKTable) RemoteAddr(remotePK cipher.PubKey) string {
 	return t.entries[remotePK]
 }
 
-func (t *inMemoryPKTable) RemotePK(remoteIP net.IP) cipher.PubKey {
-	for pk, addr := range t.entries {
-		if addr.IP.String() == remoteIP.String() {
-			return pk
-		}
+func (t *memPKTable) RemotePK(address string) cipher.PubKey {
+	addr, err := net.ResolveTCPAddr("tcp", address)
+	if err != nil {
+		panic("net.ResolveTCPAddr")
 	}
+	return t.reverse[addr.IP.String()]
+}
 
-	return cipher.PubKey{}
+func (t *memPKTable) Count() int {
+	return len(t.entries)
 }
 
 type filePKTable struct {
-	dbFile *os.File
+	dbFile string
+	*memPKTable
 }
 
 // FilePubKeyTable returns file based implementation of the PubKeyTable.
@@ -144,43 +195,8 @@ func FilePubKeyTable(dbFile string) (PubKeyTable, error) {
 		return nil, err
 	}
 
-	return &filePKTable{f}, nil
-}
-
-func (t *filePKTable) RemoteAddr(remotePK cipher.PubKey) *net.TCPAddr {
-	var raddr *net.TCPAddr
-	t.Seek(func(pk cipher.PubKey, addr *net.TCPAddr) bool {
-		if pk == remotePK {
-			raddr = addr
-			return true
-		}
-
-		return false
-	})
-	return raddr
-}
-
-func (t *filePKTable) RemotePK(remoteIP net.IP) cipher.PubKey {
-	var rpk cipher.PubKey
-	t.Seek(func(pk cipher.PubKey, addr *net.TCPAddr) bool {
-		if remoteIP.String() == addr.IP.String() {
-			rpk = pk
-			return true
-		}
-
-		return false
-	})
-	return rpk
-}
-
-func (t *filePKTable) Seek(seekFunc func(pk cipher.PubKey, addr *net.TCPAddr) bool) {
-	defer func() {
-		if _, err := t.dbFile.Seek(0, 0); err != nil {
-			log.WithError(err).Warn("Failed to seek to the beginning of DB")
-		}
-	}()
-
-	scanner := bufio.NewScanner(t.dbFile)
+	entries := make(map[cipher.PubKey]string)
+	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		components := strings.Fields(scanner.Text())
 		if len(components) != 2 {
@@ -197,8 +213,8 @@ func (t *filePKTable) Seek(seekFunc func(pk cipher.PubKey, addr *net.TCPAddr) bo
 			continue
 		}
 
-		if seekFunc(pk, addr) {
-			return
-		}
+		entries[pk] = addr.String()
 	}
+
+	return &filePKTable{dbFile, memoryPubKeyTable(entries)}, nil
 }

--- a/pkg/transport/tcp_transport_test.go
+++ b/pkg/transport/tcp_transport_test.go
@@ -1,3 +1,5 @@
+// +build !no_ci
+
 package transport_test
 
 import (
@@ -6,14 +8,110 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/skycoin/dmsg/cipher"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	th "github.com/skycoin/skywire/internal/testhelpers"
 	"github.com/skycoin/skywire/pkg/transport"
 )
+
+/*
+   TCP-Transport tests requires preconfigured IP aliases on on host
+
+   Linux: `for ((i=1; i<=255; i++)){sudo ip addr add 12.12.12.$i/32 dev lo}`
+
+   MacOS:
+   ```bash
+   $ brew install iproute2mac
+   $ for ((i=1; i<=255; i++)){sudo ip addr add 12.12.12.$i/32 dev lo0} # note lo0
+   ```
+*/
+
+func pkFromSeed(seed string) cipher.PubKey {
+	pk, _, err := cipher.GenerateDeterministicKeyPair([]byte(seed))
+	if err != nil {
+		return cipher.PubKey{}
+	}
+	return pk
+}
+
+func Example_transport_TCPFactory() {
+	pkA := pkFromSeed("12.12.12.1")
+	pkB := pkFromSeed("12.12.12.2")
+	ipA := "12.12.12.1:9119"
+	ipB := "12.12.12.2:9119"
+
+	addrA, _ := net.ResolveTCPAddr("tcp", ipA)
+	lsnA, err := net.ListenTCP("tcp", addrA)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	addrB, _ := net.ResolveTCPAddr("tcp", ipB)
+	lsnB, err := net.ListenTCP("tcp", addrB)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	pkt := transport.MemoryPubKeyTable(
+		map[cipher.PubKey]string{
+			pkA: addrA.String(),
+			pkB: addrB.String(),
+		})
+
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+
+		fA := &transport.TCPFactory{pkA, pkt, lsnA}
+		tr, err := fA.Accept(context.TODO())
+		if err != nil {
+			fmt.Printf("Accept err: %v\n", err)
+			return
+		}
+		fmt.Printf("Accept success: %v\n", err == nil)
+
+		if _, err := tr.Write([]byte("Hallo!")); err != nil {
+			fmt.Printf("Write err: %v\n", err)
+			return
+		}
+		fmt.Printf("Write success: %v\n", err == nil)
+		return
+	}()
+
+	go func() {
+		defer wg.Done()
+		fB := &transport.TCPFactory{pkB, pkt, lsnB}
+		tr, err := fB.Dial(context.TODO(), pkA)
+		if err != nil {
+			fmt.Printf("Dial err: %v\n", err)
+		}
+		fmt.Printf("Dial success: %v\n", err == nil)
+
+		buf := make([]byte, 6)
+		_, err = tr.Read(buf)
+		if err != nil {
+			fmt.Printf("Read err: %v\n", err)
+		}
+
+		fmt.Printf("Message recieved: %s\n", buf)
+	}()
+	wg.Wait()
+
+	fmt.Println("Finish")
+
+	// Unordered output: Accept success: true
+	// Write success: true
+	// Dial success: true
+	// Message recieved: Hallo!
+	// Finish
+}
 
 func TestTCPFactory(t *testing.T) {
 	pk1, _ := cipher.GenerateKeyPair()
@@ -29,45 +127,65 @@ func TestTCPFactory(t *testing.T) {
 	l2, err := net.ListenTCP("tcp", addr2)
 	require.NoError(t, err)
 
-	pkt1 := transport.InMemoryPubKeyTable(map[cipher.PubKey]*net.TCPAddr{pk2: addr2})
-	pkt2 := transport.InMemoryPubKeyTable(map[cipher.PubKey]*net.TCPAddr{pk1: addr1})
+	pkt1 := transport.MemoryPubKeyTable(map[cipher.PubKey]string{pk2: addr2.String()})
+	pkt2 := transport.MemoryPubKeyTable(map[cipher.PubKey]string{pk1: addr1.String()})
 
-	f1 := transport.NewTCPFactory(pk1, pkt1, l1)
-	errCh := make(chan error)
+	f1 := &transport.TCPFactory{pk1, pkt1, l1}
+	f2 := &transport.TCPFactory{pk2, pkt2, l2}
+	require.Equal(t, "tcp-transport", f1.Type())
+	require.Equal(t, pk1, f1.Local())
+	require.Equal(t, "tcp-transport", f2.Type())
+	require.Equal(t, pk2, f2.Local())
+
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+	errAcceptCh := make(chan error)
 	go func() {
 		tr, err := f1.Accept(context.TODO())
 		if err != nil {
-			errCh <- err
+			errAcceptCh <- err
 			return
 		}
 
-		if _, err := tr.Write([]byte("foo")); err != nil {
-			errCh <- err
+		if _, err := tr.Write([]byte("Hello!")); err != nil {
+			errAcceptCh <- err
 			return
 		}
 
-		errCh <- nil
+		require.NoError(t, tr.Close())
+		close(errAcceptCh)
+		wg.Done()
 	}()
 
-	f2 := transport.NewTCPFactory(pk2, pkt2, l2)
-	assert.Equal(t, "tcp", f2.Type())
-	assert.Equal(t, pk2, f2.Local())
+	errDialCh := make(chan error)
+	go func() {
+		tr, err := f2.Dial(context.TODO(), pk1)
+		if err != nil {
+			errDialCh <- err
+		}
 
-	tr, err := f2.Dial(context.TODO(), pk1)
-	require.NoError(t, err)
-	assert.Equal(t, "tcp", tr.Type())
+		buf := make([]byte, 6)
+		_, err = tr.Read(buf)
+		if err != nil {
+			errDialCh <- err
+		}
 
-	buf := make([]byte, 3)
-	_, err = tr.Read(buf)
-	require.NoError(t, err)
-	assert.Equal(t, []byte("foo"), buf)
+		assert.Equal(t, []byte("Hello!"), buf)
+		require.NoError(t, tr.Close())
 
-	require.NoError(t, tr.Close())
-	require.NoError(t, f2.Close())
-	require.NoError(t, f1.Close())
+		close(errDialCh)
+		wg.Done()
+	}()
+
+	wg.Wait()
+
+	th.NoErrorN(t, <-errAcceptCh, <-errDialCh,
+		f2.Close(), f1.Close())
+
 }
 
-func TestFilePKTable(t *testing.T) {
+func TestFilePubKeyTable(t *testing.T) {
 	pk, _ := cipher.GenerateKeyPair()
 
 	tmpfile, err := ioutil.TempFile("", "pktable")
@@ -84,10 +202,65 @@ func TestFilePKTable(t *testing.T) {
 
 	pkt, err := transport.FilePubKeyTable(tmpfile.Name())
 	require.NoError(t, err)
+	require.Equal(t, pkt.Count(), 1)
 
 	raddr := pkt.RemoteAddr(pk)
-	assert.Equal(t, addr, raddr)
+	assert.Equal(t, addr.String(), raddr)
 
-	rpk := pkt.RemotePK(addr.IP)
+	rpk := pkt.RemotePK(addr.String())
 	assert.Equal(t, pk, rpk)
+}
+
+func Example_transport_MemoryPubKeyTable() {
+	pkA, pkB := pkFromSeed("nodeA"), pkFromSeed("nodeB")
+	ipA, ipB := "12.12.12.1:9119", "skyhost_003:9119"
+	ipAA := "12.12.12.1:54312"
+	entries := map[cipher.PubKey]string{
+		pkA: ipA,
+		pkB: ipB,
+	}
+	pkt := transport.MemoryPubKeyTable(entries)
+
+	fmt.Printf("ipA: %v\n", pkt.RemoteAddr(pkA))
+	fmt.Printf("pkB in: %v\n", pkt.RemotePK(ipA))
+	fmt.Printf("pkA out: %v\n", pkt.RemotePK(ipAA))
+
+	// Output: ipA: 12.12.12.1:9119
+	// pkB in: 03c8ab0302ecda8564df4bce595c456a03b64871caff699fcafaf24a93058474ab
+	// pkA out: 03c8ab0302ecda8564df4bce595c456a03b64871caff699fcafaf24a93058474ab
+}
+
+func Example_transport_FilePubKeyTable() {
+	pkA, pkB := pkFromSeed("nodeA"), pkFromSeed("nodeB")
+	ipA, ipB := "12.12.12.1:9119", "12.12.12.2:9119"
+	ipAA := "12.12.12.1:54312"
+
+	pkFileContent :=
+		fmt.Sprintf("%v%v",
+			fmt.Sprintf("%s\t%s\n", pkA, ipA),
+			fmt.Sprintf("%s\t%s\n", pkB, ipB))
+	fmt.Printf("pubkeys:\n%v", pkFileContent)
+
+	tmpfile, _ := ioutil.TempFile("", "pktable")
+
+	_, err := tmpfile.Write([]byte(pkFileContent))
+	fmt.Printf("Write file success: %v\n", err == nil)
+
+	pkt, err := transport.FilePubKeyTable(tmpfile.Name())
+
+	fmt.Printf("Opening FilePubKeyTable success: %v\n", err == nil)
+	fmt.Printf("ipA: %v\n", pkt.RemoteAddr(pkA))
+	fmt.Printf("PK for ipA: %v\n", pkt.RemotePK(ipA))
+	fmt.Printf("PK for ipAA: %v\n", pkt.RemotePK(ipAA))
+	fmt.Printf("PK for ipB: %v\n", pkt.RemotePK(ipB))
+
+	// Output: pubkeys:
+	// 03c8ab0302ecda8564df4bce595c456a03b64871caff699fcafaf24a93058474ab	12.12.12.1:9119
+	// 033978326862c191eaa39e33bb556a6296466facfe36bfb81e6b4c99d9c510e09f	12.12.12.2:9119
+	// Write file success: true
+	// Opening FilePubKeyTable success: true
+	// ipA: 12.12.12.1:9119
+	// PK for ipA: 03c8ab0302ecda8564df4bce595c456a03b64871caff699fcafaf24a93058474ab
+	// PK for ipAA: 03c8ab0302ecda8564df4bce595c456a03b64871caff699fcafaf24a93058474ab
+	// PK for ipB: 033978326862c191eaa39e33bb556a6296466facfe36bfb81e6b4c99d9c510e09f
 }


### PR DESCRIPTION
It's a part of bigger and unfinished tcp-transport PR.

Here:
- Fix of tcp-transport itself - it did not send laddr during Dial so
on Accept on another edge was broken
- Fix of memoryPubKeyTable: reverse search of pk was broken
- FilePubKeyTable - simplified, now composed from memoryPubKeyTable
- tests of tcp-transport - under no_ci tags because they need prepared IP addresses
- .travis-ci now prepares IP aliases for tests

Also: 
Fixed message `can't load package: package github.com/skycoin/skywire: unknown import path "github.com/skycoin/skywire": cannot find module providing package github.com/skycoin/skywire` during commands like `go clean`

