### PR TITLE
Fix linter errors

### DIFF
--- a/pkg/router/route_manager_test.go
+++ b/pkg/router/route_manager_test.go
@@ -25,7 +25,7 @@ func TestNewRouteManager(t *testing.T) {
 
 	rt := routing.InMemoryRoutingTable()
 
-	rm, err := NewRouteManager(env.Nets[0], rt, RMConfig{})
+	rm, err := newRouteManager(env.Nets[0], rt, RMConfig{})
 	require.NoError(t, err)
 	defer func() { require.NoError(t, rm.Close()) }()
 

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -69,7 +69,7 @@ type Router struct {
 	n  *snet.Network
 	tm *transport.Manager
 	pm *portManager
-	rm *routeManager
+	rm *RouteManager
 
 	wg sync.WaitGroup
 	mx sync.Mutex
@@ -428,6 +428,7 @@ fetchRoutesAgain:
 	return fwdRoutes[0], revRoutes[0], nil
 }
 
+// SetupIsTrusted checks if setup node is trusted.
 func (r *Router) SetupIsTrusted(sPK cipher.PubKey) bool {
 	return r.rm.conf.SetupIsTrusted(sPK)
 }

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -69,7 +69,7 @@ type Router struct {
 	n  *snet.Network
 	tm *transport.Manager
 	pm *portManager
-	rm *RouteManager
+	rm *routeManager
 
 	wg sync.WaitGroup
 	mx sync.Mutex
@@ -89,7 +89,7 @@ func New(n *snet.Network, config *Config) (*Router, error) {
 	}
 
 	// Prepare route manager.
-	rm, err := NewRouteManager(n, config.RoutingTable, RMConfig{
+	rm, err := newRouteManager(n, config.RoutingTable, RMConfig{
 		SetupPKs:               config.SetupNodes,
 		GarbageCollectDuration: config.GarbageCollectDuration,
 		OnConfirmLoop:          r.confirmLoop,

--- a/pkg/setup/node.go
+++ b/pkg/setup/node.go
@@ -304,6 +304,7 @@ func (sn *Node) createRoute(ctx context.Context, expireAt time.Time, route routi
 			rulesSetupErr = err
 		}
 	}
+	cancelOnce.Do(cancel)
 
 	// close chan to avoid leaks
 	close(rulesSetupErrs)

--- a/pkg/setup/node_test.go
+++ b/pkg/setup/node_test.go
@@ -103,7 +103,11 @@ func TestNode(t *testing.T) {
 			dmsgL:   listener,
 			metrics: metrics.NewDummy(),
 		}
-		go func() { _ = sn.Serve(context.TODO()) }() //nolint:errcheck
+		go func() {
+			if err := sn.Serve(context.TODO()); err != nil {
+				sn.Logger.WithError(err).Error("Failed to serve")
+			}
+		}()
 		return sn, func() {
 			require.NoError(t, sn.Close())
 		}
@@ -206,7 +210,8 @@ func TestNode(t *testing.T) {
 			}
 
 			// TODO: This error is not checked due to a bug in dmsg.
-			_ = proto.WritePacket(RespSuccess, nil) //nolint:errcheck
+			err = proto.WritePacket(RespSuccess, nil)
+			_ = err
 
 			fmt.Printf("client %v:%v responded for PacketAddRules\n", client, clients[client].Addr)
 
@@ -240,7 +245,8 @@ func TestNode(t *testing.T) {
 			}
 
 			// TODO: This error is not checked due to a bug in dmsg.
-			_ = proto.WritePacket(RespSuccess, nil) //nolint:errcheck
+			err = proto.WritePacket(RespSuccess, nil)
+			_ = err
 
 			require.NoError(t, tp.Close())
 		}
@@ -333,7 +339,8 @@ func TestNode(t *testing.T) {
 		require.Equal(t, ld.Loop.Local, d.Loop.Remote)
 
 		// TODO: This error is not checked due to a bug in dmsg.
-		_ = proto.WritePacket(RespSuccess, nil) //nolint:errcheck
+		err = proto.WritePacket(RespSuccess, nil)
+		_ = err
 	})
 }
 

--- a/pkg/snet/snettest/env.go
+++ b/pkg/snet/snettest/env.go
@@ -87,7 +87,7 @@ func NewEnv(t *testing.T, keys []KeyPair) *Env {
 	}
 }
 
-// TearDown shutdowns the Env.
+// Teardown shutdowns the Env.
 func (e *Env) Teardown() { e.teardown() }
 
 func createDmsgSrv(t *testing.T, dc disc.APIClient) (srv *dmsg.Server, srvErr <-chan error) {

--- a/pkg/therealssh/session.go
+++ b/pkg/therealssh/session.go
@@ -105,7 +105,8 @@ func (s *Session) Run(command string) ([]byte, error) {
 	}() // Best effort.
 
 	// as stated in https://github.com/creack/pty/issues/21#issuecomment-513069505 we can ignore this error
-	res, _ := ioutil.ReadAll(ptmx) // nolint: err
+	res, err := ioutil.ReadAll(ptmx)
+	_ = err
 	return res, nil
 }
 

--- a/pkg/visor/config.go
+++ b/pkg/visor/config.go
@@ -161,12 +161,13 @@ func ensureDir(path string) (string, error) {
 	return absPath, nil
 }
 
-// HypervisorConfig represents a connection to a hypervisor.
+// HypervisorConfig represents hypervisor configuration.
 type HypervisorConfig struct {
 	PubKey cipher.PubKey `json:"public_key"`
 	Addr   string        `json:"address"`
 }
 
+// DmsgConfig represents dmsg configuration.
 type DmsgConfig struct {
 	PubKey     cipher.PubKey
 	SecKey     cipher.SecKey

--- a/pkg/visor/visor_test.go
+++ b/pkg/visor/visor_test.go
@@ -291,3 +291,7 @@ func (r *mockRouter) Close() error {
 func (r *mockRouter) IsSetupTransport(tr *transport.ManagedTransport) bool {
 	return false
 }
+
+func (r *mockRouter) SetupIsTrusted(sPK cipher.PubKey) bool {
+	return true
+}


### PR DESCRIPTION
Right now, TravisCI builds fail for all pull requests on `mainnet-milestone` branch because it contains linter errors. This PR fixes the errors that break builds.