### PR TITLE
Feature: Trigger build in skywire-services after merge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ DOCKER_NODE?=SKY01
 DOCKER_OPTS?=GO111MODULE=on GOOS=linux # go options for compiling for docker container
 TEST_OPTS?=-race -tags no_ci -cover -timeout=5m
 BUILD_OPTS?=-race
+SWC_BRANCH_NAME?=CICD/INTEGRATION_BUILD
 
 check: lint test ## Run linters and tests
 
@@ -189,6 +190,14 @@ mod-comm: ## Comments the 'replace' rule in go.mod
 
 mod-uncomm: ## Uncomments the 'replace' rule in go.mod
 	./ci_scripts/go_mod_replace.sh uncomment go.mod
+
+trigger-swc-build: ## Trigger integration build in skywire-services
+	SWC_BRANCH_NAME=$(SWC_BRANCH_NAME) ./ci_scripts/trigger-swc-build.sh
+
+vendor-integration-check: ## Check compatibility of master@skywire-services with last vendored packages
+	./ci_scripts/vendor-integration-check.sh
+
+
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/ci_scripts/trigger-swc-build.sh
+++ b/ci_scripts/trigger-swc-build.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+body='{
+"request": {
+    "branch":"'$SWC_BRANCH_NAME'",
+    "message":"'$TRIGGER_MESSAGE'", 
+    "config": {  
+      "merge_mode": "merge",
+      "install": "DOCKER_COMPOSE_VERSION=1.24.1 ci_scripts/install-docker-compose.sh;",
+      "script": "make vendor-integration-check",      
+      "deploy":{
+        "provider": "script",
+        "script": "echo disabled"
+      }
+    }
+}}'
+
+curl -s -X POST \
+   -H "Content-Type: application/json" \
+   -H "Accept: application/json" \
+   -H "Travis-API-Version: 3" \
+   -H "Authorization: token $TRAVIS_API_TOKEN" \
+   -d "$body" \
+   https://api.travis-ci.com/repo/watercompany%2Fskywire-services/requests

--- a/ci_scripts/vendor-integration-check.sh
+++ b/ci_scripts/vendor-integration-check.sh
@@ -4,12 +4,18 @@ export GO111MODULE=on
 export COMPOSE_FILE=docker-compose.yml:docker-compose.nodes.yml
 set -e -x
 
+# Store current path
+export SWPATH=$(pwd)
+
 # Clone from master
 rm -rf /tmp/skywire-services &> /dev/null
 cd /tmp
 git clone https://$GITHUB_TOKEN:x-oauth-basic@github.com/watercompany/skywire-services.git  --branch master --depth 1
 # git clone git@github.com:watercompany/skywire-services.git --branch master --depth 1
 cd skywire-services
+
+# go mod edit
+go mod edit  -replace=github.com/skycoin/skywire@mainnet=$SWPATH
 
 # Checking build 
 make dep

--- a/ci_scripts/vendor-integration-check.sh
+++ b/ci_scripts/vendor-integration-check.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+export GO111MODULE=on
+export COMPOSE_FILE=docker-compose.yml:docker-compose.nodes.yml
+set -e -x
+
+# Clone from master
+rm -rf /tmp/skywire-services &> /dev/null
+cd /tmp
+git clone https://$GITHUB_TOKEN:x-oauth-basic@github.com/watercompany/skywire-services.git  --branch master --depth 1
+# git clone git@github.com:watercompany/skywire-services.git --branch master --depth 1
+cd skywire-services
+
+# Checking build 
+make dep
+make build
+
+# Running regular tests
+make test
+
+# Checking e2e-build
+make e2e-clean
+make e2e-build
+make e2e-run
+
+# Running e2e tests
+make e2e-test


### PR DESCRIPTION
This is second version of this.

First (https://github.com/skycoin/skywire/pull/542) was based on mainnet-milestone1 by mistake.

Changes are the same:
- ./ci_scripts/trigger-swc-build.sh               - trigger build in skywire-services
- ./ci_scritps/vendor-integration-check.sh  - local integration check

Requires env vars:
-  $TRAVIS_API_TOKEN -  `--pro`  travis api token 
- $GITHUB_TOKEN - github token wtih scope `repo`