### PR TITLE
Fix issues in implementation of command execution on visor from hypervisor

### DIFF
--- a/cmd/skywire-cli/commands/node/app.go
+++ b/cmd/skywire-cli/commands/node/app.go
@@ -92,6 +92,6 @@ var execCmd = &cobra.Command{
 	Run: func(_ *cobra.Command, args []string) {
 		out, err := rpcClient().Exec(strings.Join(args, " "))
 		internal.Catch(err)
-		fmt.Println(string(out))
+		fmt.Print(string(out))
 	},
 }

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,7 @@ golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa h1:KIDDMLT1O0Nr7TSxp8xM5tJcd
 golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190825160603-fb81701db80f h1:LCxigP8q3fPRGNVYndYsyHnF0zRrvcoVwZMfb8iQZe4=
 golang.org/x/sys v0.0.0-20190825160603-fb81701db80f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/pkg/hypervisor/hypervisor.go
+++ b/pkg/hypervisor/hypervisor.go
@@ -129,7 +129,7 @@ func (m *Node) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			}
 			r.Get("/user", m.users.UserInfo())
 			r.Post("/change-password", m.users.ChangePassword())
-			r.Post("/exec", m.exec())
+			r.Post("/exec/{pk}", m.exec())
 			r.Get("/nodes", m.getNodes())
 			r.Get("/nodes/{pk}", m.getNode())
 			r.Get("/nodes/{pk}/apps", m.getApps())

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -3,7 +3,6 @@ package visor
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/skycoin/skywire/pkg/router"
 	"math/rand"
 	"net/rpc"
 	"sync"
@@ -13,6 +12,7 @@ import (
 	"github.com/skycoin/dmsg/cipher"
 	"github.com/skycoin/skycoin/src/util/logging"
 
+	"github.com/skycoin/skywire/pkg/router"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/transport"
 )

--- a/vendor/github.com/skycoin/dmsg/client.go
+++ b/vendor/github.com/skycoin/dmsg/client.go
@@ -158,7 +158,7 @@ func (c *Client) findServerEntries(ctx context.Context) ([]*disc.Entry, error) {
 				return nil, fmt.Errorf("dms_servers are not available: %s", err)
 			default:
 				retry := time.Second
-				c.log.WithError(err).Warnf("no dms_servers found: trying again in %d second...", retry)
+				c.log.WithError(err).Warnf("no dms_servers found: trying again in %v...", retry)
 				time.Sleep(retry)
 				continue
 			}

--- a/vendor/golang.org/x/sys/windows/syscall_windows.go
+++ b/vendor/golang.org/x/sys/windows/syscall_windows.go
@@ -296,6 +296,7 @@ func NewCallbackCDecl(fn interface{}) uintptr {
 //sys	coCreateGuid(pguid *GUID) (ret error) = ole32.CoCreateGuid
 //sys	CoTaskMemFree(address unsafe.Pointer) = ole32.CoTaskMemFree
 //sys	rtlGetVersion(info *OsVersionInfoEx) (ret error) = ntdll.RtlGetVersion
+//sys	rtlGetNtVersionNumbers(majorVersion *uint32, minorVersion *uint32, buildNumber *uint32) = ntdll.RtlGetNtVersionNumbers
 
 // syscall interface implementation for other packages
 
@@ -1306,8 +1307,8 @@ func (t Token) KnownFolderPath(folderID *KNOWNFOLDERID, flags uint32) (string, e
 	return UTF16ToString((*[(1 << 30) - 1]uint16)(unsafe.Pointer(p))[:]), nil
 }
 
-// RtlGetVersion returns the true version of the underlying operating system, ignoring
-// any manifesting or compatibility layers on top of the win32 layer.
+// RtlGetVersion returns the version of the underlying operating system, ignoring
+// manifest semantics but is affected by the application compatibility layer.
 func RtlGetVersion() *OsVersionInfoEx {
 	info := &OsVersionInfoEx{}
 	info.osVersionInfoSize = uint32(unsafe.Sizeof(*info))
@@ -1317,4 +1318,12 @@ func RtlGetVersion() *OsVersionInfoEx {
 	// that the documentation is indeed correct about that.
 	_ = rtlGetVersion(info)
 	return info
+}
+
+// RtlGetNtVersionNumbers returns the version of the underlying operating system,
+// ignoring manifest semantics and the application compatibility layer.
+func RtlGetNtVersionNumbers() (majorVersion, minorVersion, buildNumber uint32) {
+	rtlGetNtVersionNumbers(&majorVersion, &minorVersion, &buildNumber)
+	buildNumber &= 0xffff
+	return
 }

--- a/vendor/golang.org/x/sys/windows/zsyscall_windows.go
+++ b/vendor/golang.org/x/sys/windows/zsyscall_windows.go
@@ -234,6 +234,7 @@ var (
 	procCoCreateGuid                       = modole32.NewProc("CoCreateGuid")
 	procCoTaskMemFree                      = modole32.NewProc("CoTaskMemFree")
 	procRtlGetVersion                      = modntdll.NewProc("RtlGetVersion")
+	procRtlGetNtVersionNumbers             = modntdll.NewProc("RtlGetNtVersionNumbers")
 	procWSAStartup                         = modws2_32.NewProc("WSAStartup")
 	procWSACleanup                         = modws2_32.NewProc("WSACleanup")
 	procWSAIoctl                           = modws2_32.NewProc("WSAIoctl")
@@ -2527,6 +2528,11 @@ func rtlGetVersion(info *OsVersionInfoEx) (ret error) {
 	if r0 != 0 {
 		ret = syscall.Errno(r0)
 	}
+	return
+}
+
+func rtlGetNtVersionNumbers(majorVersion *uint32, minorVersion *uint32, buildNumber *uint32) {
+	syscall.Syscall(procRtlGetNtVersionNumbers.Addr(), 3, uintptr(unsafe.Pointer(majorVersion)), uintptr(unsafe.Pointer(minorVersion)), uintptr(unsafe.Pointer(buildNumber)))
 	return
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -98,7 +98,7 @@ golang.org/x/net/nettest
 golang.org/x/net/context
 golang.org/x/net/proxy
 golang.org/x/net/internal/socks
-# golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a
+# golang.org/x/sys v0.0.0-20190825160603-fb81701db80f
 golang.org/x/sys/unix
 golang.org/x/sys/windows
 golang.org/x/sys/windows/svc/eventlog


### PR DESCRIPTION
Closes #551 

Done:

1. Fix the `/exec` endpoint
2. Remove a redundant new line when using the command-line interface